### PR TITLE
Zero index hardcoded test cases

### DIFF
--- a/test/python/transpiler/test_commutation_analysis.py
+++ b/test/python/transpiler/test_commutation_analysis.py
@@ -86,18 +86,18 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1],
+        expected = {'qr[0]': [[0],
+                              [4],
                               [5],
                               [6],
-                              [7],
-                              [8, 9, 10, 11],
+                              [7, 8, 9, 10],
+                              [11],
                               [12],
                               [13],
                               [14],
                               [15],
-                              [16],
-                              [2]],
-                    'qr[1]': [[3], [14], [15], [16], [4]]}
+                              [1]],
+                    'qr[1]': [[2], [13], [14], [15], [3]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_non_commutative_circuit(self):
@@ -116,7 +116,7 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [7], [2]], 'qr[1]': [[3], [8], [4]], 'qr[2]': [[5], [9], [6]]}
+        expected = {'qr[0]': [[0], [6], [1]], 'qr[1]': [[2], [7], [3]], 'qr[2]': [[4], [8], [5]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_non_commutative_circuit_2(self):
@@ -137,9 +137,9 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [7], [2]],
-                    'qr[1]': [[3], [7], [9], [4]],
-                    'qr[2]': [[5], [8], [9], [6]]}
+        expected = {'qr[0]': [[0], [6], [1]],
+                    'qr[1]': [[2], [6], [8], [3]],
+                    'qr[2]': [[4], [7], [8], [5]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_commutative_circuit(self):
@@ -161,9 +161,9 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [7], [2]],
-                    'qr[1]': [[3], [7, 9], [4]],
-                    'qr[2]': [[5], [8], [9], [6]]}
+        expected = {'qr[0]': [[0], [6], [1]],
+                    'qr[1]': [[2], [6, 8], [3]],
+                    'qr[2]': [[4], [7], [8], [5]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_commutative_circuit_2(self):
@@ -187,9 +187,9 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [7, 8], [2]],
-                    'qr[1]': [[3], [7, 10], [4]],
-                    'qr[2]': [[5], [9], [10], [6]]}
+        expected = {'qr[0]': [[0], [6, 7], [1]],
+                    'qr[1]': [[2], [6, 9], [3]],
+                    'qr[2]': [[4], [8], [9], [5]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_commutative_circuit_3(self):
@@ -215,9 +215,9 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [7, 9, 11, 13], [2]],
-                    'qr[1]': [[3], [7, 10, 11], [14], [4]],
-                    'qr[2]': [[5], [8], [10], [12, 14], [6]]}
+        expected = {'qr[0]': [[0], [6, 8, 10, 12], [1]],
+                    'qr[1]': [[2], [6, 9, 10], [13], [3]],
+                    'qr[2]': [[4], [7], [9], [11, 13], [5]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_jordan_wigner_type_circuit(self):
@@ -253,12 +253,12 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [13, 23], [2]],
-                    'qr[1]': [[3], [13], [14, 22], [23], [4]],
-                    'qr[2]': [[5], [14], [15, 21], [22], [6]],
-                    'qr[3]': [[7], [15], [16, 20], [21], [8]],
-                    'qr[4]': [[9], [16], [17, 19], [20], [10]],
-                    'qr[5]': [[11], [17], [18], [19], [12]]}
+        expected = {'qr[0]': [[0], [12, 22], [1]],
+                    'qr[1]': [[2], [12], [13, 21], [22], [3]],
+                    'qr[2]': [[4], [13], [14, 20], [21], [5]],
+                    'qr[3]': [[6], [14], [15, 19], [20], [7]],
+                    'qr[4]': [[8], [15], [16, 18], [19], [9]],
+                    'qr[5]': [[10], [16], [17], [18], [11]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
     def test_all_commute_circuit(self):
@@ -279,11 +279,11 @@ class TestCommutationAnalysis(QiskitTestCase):
 
         self.pass_.run(dag)
 
-        expected = {'qr[0]': [[1], [11, 15, 17], [2]],
-                    'qr[1]': [[3], [11, 12, 17, 18], [4]],
-                    'qr[2]': [[5], [12, 14, 18, 20], [6]],
-                    'qr[3]': [[7], [13, 14, 19, 20], [8]],
-                    'qr[4]': [[9], [13, 16, 19], [10]]}
+        expected = {'qr[0]': [[0], [10, 14, 16], [1]],
+                    'qr[1]': [[2], [10, 11, 16, 17], [3]],
+                    'qr[2]': [[4], [11, 13, 17, 19], [5]],
+                    'qr[3]': [[6], [12, 13, 18, 19], [7]],
+                    'qr[4]': [[8], [12, 15, 18], [9]]}
         self.assertCommutationSet(self.pset["commutation_set"], expected)
 
 

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -296,7 +296,7 @@ class TestUseCases(SchedulerTestCase):
         self.passmanager.append(PassI_Bad_AP())
         self.assertSchedulerRaises(circ, self.passmanager,
                                    ['run analysis pass PassI_Bad_AP',
-                                    'cx_runs: {(5, 6, 7, 8)}'],
+                                    'cx_runs: {(4, 5, 6, 7)}'],
                                    TranspilerError)
 
     def test_analysis_pass_is_idempotent(self):


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The networkx node indices were one-indexed. retworkx is zero-indexed. Update hardcoded test cases to be zero indexed to match retworkx

### Details and comments


