### PR TITLE
Fix name 'Command' is not defined warnings

### DIFF
--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -27,12 +27,14 @@ import warnings
 
 from abc import ABC
 
-from typing import Tuple, List, Iterable, Callable, Optional, Union
+from typing import Tuple, List, Iterable, Callable, Optional, Union, TYPE_CHECKING
 
 from qiskit.pulse.channels import Channel
 from qiskit.pulse.interfaces import ScheduleComponent
 from qiskit.pulse.schedule import Schedule
 from qiskit.pulse.timeslots import Interval, Timeslot, TimeslotCollection
+if TYPE_CHECKING:
+    from qiskit.pulse.commands import Command
 
 # pylint: disable=missing-return-doc
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix name 'Command' is not defined warnings

### Details and comments

I've used typing.TYPE_CHECKING here, to not run into cyclic imports. 
```
if TYPE_CHECKING:
   from foo import Foo
```
`Foo` will be imported only during type checking. It actually converts `Foo` to `ForwardRef(Foo)`. But I don't personally like the way docs are built.
<img width="463" alt="image" src="https://user-images.githubusercontent.com/11485594/75481221-b10f4a80-5970-11ea-98fb-024f5355fe5e.png">
Its shows `style (Optional[ForwardRef]) – A style sheet to configure plot appearance` instead of `style (Optional[Foo]) – A style sheet to configure plot appearance` 😞 

