### PR TITLE
Fix all sphinx warnings

### DIFF
--- a/qiskit/pulse/commands/acquire.py
+++ b/qiskit/pulse/commands/acquire.py
@@ -18,7 +18,7 @@ Acquire.
 import warnings
 from typing import Optional, Union, List
 
-from qiskit.pulse.channels import MemorySlot, RegisterSlot, AcquireChannel
+from qiskit.pulse import MemorySlot, RegisterSlot, AcquireChannel
 from qiskit.pulse.exceptions import PulseError
 from .instruction import Instruction
 from .meas_opts import Discriminator, Kernel

--- a/qiskit/pulse/commands/command.py
+++ b/qiskit/pulse/commands/command.py
@@ -24,8 +24,6 @@ import numpy as np
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.channels import Channel
 
-from .instruction import Instruction
-
 
 class MetaCount(ABCMeta):
     """Meta class to count class instances."""
@@ -91,8 +89,12 @@ class Command(metaclass=MetaCount):
 
     @abstractmethod
     def to_instruction(self, command, *channels: List[Channel],
-                       name: Optional[str] = None) -> Instruction:
-        """Create an instruction from command."""
+                       name: Optional[str] = None):
+        """Create an instruction from command.
+
+        Returns:
+            Instruction
+        """
         pass
 
     def __call__(self, *args, **kwargs):

--- a/qiskit/pulse/commands/parametric_pulses.py
+++ b/qiskit/pulse/commands/parametric_pulses.py
@@ -38,21 +38,18 @@ by following the existing pattern:
         new_supported_pulse_name = commands.YourPulseCommandClass
 """
 from abc import abstractmethod
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional
 import math
 
 import numpy as np
 
-from qiskit.pulse.channels import PulseChannel
-from qiskit.pulse.exceptions import PulseError
-from qiskit.pulse.pulse_lib.discrete import gaussian, gaussian_square, drag, constant
-from qiskit.pulse.pulse_lib import continuous
-
-from .pulse_command import PulseCommand
+from qiskit.pulse.pulse_lib import gaussian, gaussian_square, drag, constant, continuous
 from .sample_pulse import SamplePulse
 from .instruction import Instruction
-if TYPE_CHECKING:
-    from qiskit.visualization.pulse.qcstyle import PulseStyle
+from ..channels import PulseChannel
+from ..exceptions import PulseError
+
+from .pulse_command import PulseCommand
 
 # pylint: disable=missing-docstring
 
@@ -255,11 +252,10 @@ class GaussianSquare(ParametricPulse):
 
 
 class Drag(ParametricPulse):
-    """
-    The Derivative Removal by Adiabatic Gate (DRAG) pulse is a standard Gaussian pulse
+    """The Derivative Removal by Adiabatic Gate (DRAG) pulse is a standard Gaussian pulse
     with an additional Gaussian derivative component. It is designed to reduce the frequency
-    spectrum of a normal gaussian pulse near the |1>-|2> transition, reducing the chance of
-    leakage to the |2> state.
+    spectrum of a normal gaussian pulse near the :math:`|1>` - :math:`|2>` transition,
+    reducing the chance of leakage to the :math:`|2>` state.
 
     .. math::
 
@@ -272,12 +268,21 @@ class Drag(ParametricPulse):
 
         Gaussian(x, amp, sigma) = amp * exp( -(1/2) * (x - duration/2)^2 / sigma^2) )
 
-    Ref:
-        [1] Gambetta, J. M., Motzoi, F., Merkel, S. T. & Wilhelm, F. K.
-        Analytic control methods for high-fidelity unitary operations
-        in a weakly nonlinear oscillator. Phys. Rev. A 83, 012308 (2011).
-        [2] F. Motzoi, J. M. Gambetta, P. Rebentrost, and F. K. Wilhelm
-        Phys. Rev. Lett. 103, 110501 – Published 8 September 2009
+    References:
+        1. |citation1|_
+
+        .. _citation1: https://link.aps.org/doi/10.1103/PhysRevA.83.012308
+
+        .. |citation1| replace:: *Gambetta, J. M., Motzoi, F., Merkel, S. T. & Wilhelm, F. K.
+           Analytic control methods for high-fidelity unitary operations
+           in a weakly nonlinear oscillator. Phys. Rev. A 83, 012308 (2011).*
+
+        2. |citation2|_
+
+        .. _citation2: https://link.aps.org/doi/10.1103/PhysRevLett.103.110501
+
+        .. |citation2| replace:: *F. Motzoi, J. M. Gambetta, P. Rebentrost, and F. K. Wilhelm
+           Phys. Rev. Lett. 103, 110501 – Published 8 September 2009.*
     """
 
     def __init__(self,

--- a/qiskit/pulse/commands/parametric_pulses.py
+++ b/qiskit/pulse/commands/parametric_pulses.py
@@ -96,7 +96,7 @@ class ParametricPulse(PulseCommand):
         return ParametricInstruction(self, channel, name=name)
 
     def draw(self, dt: float = 1,
-             style: Optional['PulseStyle'] = None,
+             style = None,
              filename: Optional[str] = None,
              interp_method: Optional[Callable] = None,
              scale: float = 1, interactive: bool = False,
@@ -105,7 +105,7 @@ class ParametricPulse(PulseCommand):
 
         Args:
             dt: Time interval of samples.
-            style: A style sheet to configure plot appearance
+            style (Optional[PulseStyle]): A style sheet to configure plot appearance
             filename: Name required to save pulse image
             interp_method: A function for interpolation
             scale: Relative visual scaling of waveform amplitudes

--- a/qiskit/pulse/commands/pulse_command.py
+++ b/qiskit/pulse/commands/pulse_command.py
@@ -13,15 +13,13 @@
 # that they have been altered from the originals.
 
 """Any command which implements a transmit signal on a channel."""
-from typing import Callable, List, Optional, TYPE_CHECKING
+from typing import Callable, List, Optional
 
 from abc import abstractmethod
 
 from qiskit.pulse.channels import Channel
 from .instruction import Instruction
 from .command import Command
-if TYPE_CHECKING:
-    from qiskit.visualization.pulse.qcstyle import PulseStyle
 
 
 class PulseCommand(Command):
@@ -39,7 +37,7 @@ class PulseCommand(Command):
 
     @abstractmethod
     def draw(self, dt: float = 1,
-             style: Optional['PulseStyle'] = None,
+             style = None,
              filename: Optional[str] = None,
              interp_method: Optional[Callable] = None,
              scale: float = 1, interactive: bool = False,
@@ -48,7 +46,7 @@ class PulseCommand(Command):
 
         Args:
             dt: Time interval of samples.
-            style: A style sheet to configure plot appearance
+            style (Optional[PulseStyle]): A style sheet to configure plot appearance
             filename: Name required to save pulse image
             interp_method: A function for interpolation
             scale: Relative visual scaling of waveform amplitudes

--- a/qiskit/pulse/commands/sample_pulse.py
+++ b/qiskit/pulse/commands/sample_pulse.py
@@ -15,7 +15,7 @@
 """
 Sample pulse.
 """
-from typing import Callable, Union, List, Optional, TYPE_CHECKING
+from typing import Callable, Union, List, Optional
 
 import warnings
 import numpy as np
@@ -25,8 +25,6 @@ from qiskit.pulse.exceptions import PulseError
 
 from .instruction import Instruction
 from .pulse_command import PulseCommand
-if TYPE_CHECKING:
-    from qiskit.visualization.pulse.qcstyle import PulseStyle
 
 
 class SamplePulse(PulseCommand):

--- a/qiskit/pulse/commands/sample_pulse.py
+++ b/qiskit/pulse/commands/sample_pulse.py
@@ -100,7 +100,7 @@ class SamplePulse(PulseCommand):
         return samples
 
     def draw(self, dt: float = 1,
-             style: Optional['PulseStyle'] = None,
+             style = None,
              filename: Optional[str] = None,
              interp_method: Optional[Callable] = None,
              scale: float = 1, interactive: bool = False,
@@ -109,7 +109,7 @@ class SamplePulse(PulseCommand):
 
         Args:
             dt: Time interval of samples.
-            style: A style sheet to configure plot appearance
+            style (Optional[PulseStyle]): A style sheet to configure plot appearance
             filename: Name required to save pulse image
             interp_method: A function for interpolation
             scale: Relative visual scaling of waveform amplitudes

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -27,15 +27,13 @@ import warnings
 
 from abc import ABC
 
-from typing import Tuple, List, Iterable, Callable, Optional, Union, TYPE_CHECKING
+from typing import Tuple, List, Iterable, Callable, Optional, Union
 
 from qiskit.pulse.channels import Channel
-from qiskit.pulse.interfaces import ScheduleComponent
-from qiskit.pulse.schedule import Schedule
 from qiskit.pulse.timeslots import Interval, Timeslot, TimeslotCollection
-if TYPE_CHECKING:
-    from qiskit.pulse.commands import Command
-    from qiskit.visualization.pulse.qcstyle import SchedStyle
+from ..interfaces import ScheduleComponent
+from ..schedule import Schedule
+from .. import commands
 
 # pylint: disable=missing-return-doc
 
@@ -47,7 +45,7 @@ class Instruction(ScheduleComponent, ABC):
     channels.
     """
 
-    def __init__(self, duration: Union['Command', int],
+    def __init__(self, duration: Union['commands.Command', int],
                  *channels: Channel,
                  name: Optional[str] = None):
         """Instruction initializer.
@@ -76,7 +74,7 @@ class Instruction(ScheduleComponent, ABC):
         return self._name
 
     @property
-    def command(self) -> 'Command':
+    def command(self) -> 'commands.Command':
         """The associated command."""
         return self._command
 
@@ -155,7 +153,7 @@ class Instruction(ScheduleComponent, ABC):
         """Return itself as already single instruction."""
         return self
 
-    def union(self, *schedules: List[ScheduleComponent], name: Optional[str] = None) -> 'Schedule':
+    def union(self, *schedules: List[ScheduleComponent], name: Optional[str] = None) -> Schedule:
         """Return a new schedule which is the union of `self` and `schedule`.
 
         Args:
@@ -166,7 +164,7 @@ class Instruction(ScheduleComponent, ABC):
             name = self.name
         return Schedule(self, *schedules, name=name)
 
-    def shift(self: ScheduleComponent, time: int, name: Optional[str] = None) -> 'Schedule':
+    def shift(self: ScheduleComponent, time: int, name: Optional[str] = None) -> Schedule:
         """Return a new schedule shifted forward by `time`.
 
         Args:
@@ -178,7 +176,7 @@ class Instruction(ScheduleComponent, ABC):
         return Schedule((time, self), name=name)
 
     def insert(self, start_time: int, schedule: ScheduleComponent,
-               name: Optional[str] = None) -> 'Schedule':
+               name: Optional[str] = None) -> Schedule:
         """Return a new :class:`~qiskit.pulse.Schedule` with ``schedule`` inserted within
         ``self`` at ``start_time``.
 
@@ -190,7 +188,7 @@ class Instruction(ScheduleComponent, ABC):
         return self.union((start_time, schedule), name=name)
 
     def append(self, schedule: ScheduleComponent,
-               name: Optional[str] = None) -> 'Schedule':
+               name: Optional[str] = None) -> Schedule:
         """Return a new :class:`~qiskit.pulse.Schedule` with ``schedule`` inserted at the
         maximum time over all channels shared between ``self`` and ``schedule``.
 
@@ -271,15 +269,15 @@ class Instruction(ScheduleComponent, ABC):
             return hash((hash(tuple(self.command)), self.channels.__hash__()))
         return hash((hash(tuple(self.duration)), self.channels.__hash__()))
 
-    def __add__(self, other: ScheduleComponent) -> 'Schedule':
+    def __add__(self, other: ScheduleComponent) -> Schedule:
         """Return a new schedule with `other` inserted within `self` at `start_time`."""
         return self.append(other)
 
-    def __or__(self, other: ScheduleComponent) -> 'Schedule':
+    def __or__(self, other: ScheduleComponent) -> Schedule:
         """Return a new schedule which is the union of `self` and `other`."""
         return self.union(other)
 
-    def __lshift__(self, time: int) -> 'Schedule':
+    def __lshift__(self, time: int) -> Schedule:
         """Return a new schedule which is shifted forward by `time`."""
         return self.shift(time)
 

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -200,7 +200,7 @@ class Instruction(ScheduleComponent, ABC):
         time = self.ch_stop_time(*common_channels)
         return self.insert(time, schedule, name=name)
 
-    def draw(self, dt: float = 1, style: Optional['SchedStyle'] = None,
+    def draw(self, dt: float = 1, style = None,
              filename: Optional[str] = None, interp_method: Optional[Callable] = None,
              scale: float = 1, channels_to_plot: Optional[List[Channel]] = None,
              plot_all: bool = False, plot_range: Optional[Tuple[float]] = None,
@@ -212,7 +212,7 @@ class Instruction(ScheduleComponent, ABC):
 
         Args:
             dt: Time interval of samples
-            style: A style sheet to configure plot appearance
+            style (Optional[SchedStyle]): A style sheet to configure plot appearance
             filename: Name required to save pulse image
             interp_method: A function for interpolation
             scale: Relative visual scaling of waveform amplitudes

--- a/qiskit/pulse/pulse_lib/discrete.py
+++ b/qiskit/pulse/pulse_lib/discrete.py
@@ -21,7 +21,8 @@ Note the sampling strategy use for all discrete pulses is `midpoint`.
 import warnings
 from typing import Optional
 
-from qiskit.pulse.pulse_lib import continuous
+from ..commands import SamplePulse
+from . import continuous
 from qiskit.pulse.exceptions import PulseError
 
 from . import samplers
@@ -30,7 +31,7 @@ from . import samplers
 _sampled_constant_pulse = samplers.midpoint(continuous.constant)
 
 
-def constant(duration: int, amp: complex, name: Optional[str] = None) -> 'SamplePulse':
+def constant(duration: int, amp: complex, name: Optional[str] = None) -> SamplePulse:
     r"""Generates constant-sampled :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, samples from the function:
@@ -50,7 +51,7 @@ def constant(duration: int, amp: complex, name: Optional[str] = None) -> 'Sample
 _sampled_zero_pulse = samplers.midpoint(continuous.zero)
 
 
-def zero(duration: int, name: Optional[str] = None) -> 'SamplePulse':
+def zero(duration: int, name: Optional[str] = None) -> SamplePulse:
     """Generates zero-sampled :class:`~qiskit.pulse.SamplePulse`.
 
     Samples from the function:
@@ -70,7 +71,7 @@ _sampled_square_pulse = samplers.midpoint(continuous.square)
 
 
 def square(duration: int, amp: complex, freq: float = None, period: float = None,
-           phase: float = 0, name: Optional[str] = None) -> 'SamplePulse':
+           phase: float = 0, name: Optional[str] = None) -> SamplePulse:
     r"""Generates square wave :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, :math:`T=` ``period``, and :math:`\phi=` ``phase``,
@@ -107,7 +108,7 @@ _sampled_sawtooth_pulse = samplers.midpoint(continuous.sawtooth)
 
 
 def sawtooth(duration: int, amp: complex, freq: float = None, period: float = None,
-             phase: float = 0, name: Optional[str] = None) -> 'SamplePulse':
+             phase: float = 0, name: Optional[str] = None) -> SamplePulse:
     r"""Generates sawtooth wave :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, :math:`T=` ``period``, and :math:`\phi=` ``phase``,
@@ -154,7 +155,7 @@ _sampled_triangle_pulse = samplers.midpoint(continuous.triangle)
 
 
 def triangle(duration: int, amp: complex, freq: float = None, period: float = None,
-             phase: float = 0, name: Optional[str] = None) -> 'SamplePulse':
+             phase: float = 0, name: Optional[str] = None) -> SamplePulse:
     r"""Generates triangle wave :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, :math:`T=` ``period``, and :math:`\phi=` ``phase``,
@@ -201,7 +202,7 @@ _sampled_cos_pulse = samplers.midpoint(continuous.cos)
 
 
 def cos(duration: int, amp: complex, freq: float = None,
-        phase: float = 0, name: Optional[str] = None) -> 'SamplePulse':
+        phase: float = 0, name: Optional[str] = None) -> SamplePulse:
     r"""Generates cosine wave :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, :math:`\omega=` ``freq``, and :math:`\phi=` ``phase``,
@@ -229,7 +230,7 @@ _sampled_sin_pulse = samplers.midpoint(continuous.sin)
 
 
 def sin(duration: int, amp: complex, freq: float = None,
-        phase: float = 0, name: Optional[str] = None) -> 'SamplePulse':
+        phase: float = 0, name: Optional[str] = None) -> SamplePulse:
     r"""Generates sine wave :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, :math:`\omega=` ``freq``, and :math:`\phi=` ``phase``,
@@ -257,7 +258,7 @@ _sampled_gaussian_pulse = samplers.midpoint(continuous.gaussian)
 
 
 def gaussian(duration: int, amp: complex, sigma: float, name: Optional[str] = None,
-             zero_ends: bool = True) -> 'SamplePulse':
+             zero_ends: bool = True) -> SamplePulse:
     r"""Generates unnormalized gaussian :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp`` and :math:`\sigma=` ``sigma``, applies the `midpoint` sampling strategy
@@ -300,7 +301,7 @@ _sampled_gaussian_deriv_pulse = samplers.midpoint(continuous.gaussian_deriv)
 
 
 def gaussian_deriv(duration: int, amp: complex, sigma: float,
-                   name: Optional[str] = None) -> 'SamplePulse':
+                   name: Optional[str] = None) -> SamplePulse:
     r"""Generates unnormalized gaussian derivative :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp`` and :math:`\sigma=` ``sigma`` applies the `midpoint` sampling strategy
@@ -326,7 +327,7 @@ _sampled_sech_pulse = samplers.midpoint(continuous.sech)
 
 
 def sech(duration: int, amp: complex, sigma: float, name: str = None,
-         zero_ends: bool = True) -> 'SamplePulse':
+         zero_ends: bool = True) -> SamplePulse:
     r"""Generates unnormalized sech :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp`` and :math:`\sigma=` ``sigma``, applies the `midpoint` sampling strategy
@@ -366,7 +367,7 @@ def sech(duration: int, amp: complex, sigma: float, name: str = None,
 _sampled_sech_deriv_pulse = samplers.midpoint(continuous.sech_deriv)
 
 
-def sech_deriv(duration: int, amp: complex, sigma: float, name: str = None) -> 'SamplePulse':
+def sech_deriv(duration: int, amp: complex, sigma: float, name: str = None) -> SamplePulse:
     r"""Generates unnormalized sech derivative :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`A=` ``amp``, :math:`\sigma=` ``sigma``, and center :math:`\mu=` ``duration/2``,
@@ -393,7 +394,7 @@ _sampled_gaussian_square_pulse = samplers.midpoint(continuous.gaussian_square)
 
 def gaussian_square(duration: int, amp: complex, sigma: float,
                     risefall: Optional[float] = None, width: Optional[float] = None,
-                    name: Optional[str] = None, zero_ends: bool = True) -> 'SamplePulse':
+                    name: Optional[str] = None, zero_ends: bool = True) -> SamplePulse:
     r"""Generates gaussian square :class:`~qiskit.pulse.SamplePulse`.
 
     For :math:`d=` ``duration``, :math:`A=` ``amp``, :math:`\sigma=` ``sigma``,
@@ -448,7 +449,7 @@ _sampled_drag_pulse = samplers.midpoint(continuous.drag)
 
 
 def drag(duration: int, amp: complex, sigma: float, beta: float,
-         name: Optional[str] = None, zero_ends: bool = True) -> 'SamplePulse':
+         name: Optional[str] = None, zero_ends: bool = True) -> SamplePulse:
     r"""Generates Y-only correction DRAG :class:`~qiskit.pulse.SamplePulse` for standard nonlinear
     oscillator (SNO) [1].
 

--- a/qiskit/pulse/reschedule.py
+++ b/qiskit/pulse/reschedule.py
@@ -22,13 +22,10 @@ from typing import List, Optional, Iterable
 
 import numpy as np
 
+from qiskit.pulse import (CmdDef, Acquire, AcquireInstruction, Delay,
+                          InstructionScheduleMap, ScheduleComponent, Schedule)
 from .channels import Channel, AcquireChannel, MeasureChannel, MemorySlot
-from .cmd_def import CmdDef
-from .commands import Acquire, AcquireInstruction, Delay
 from .exceptions import PulseError
-from .instruction_schedule_map import InstructionScheduleMap
-from .interfaces import ScheduleComponent
-from .schedule import Schedule
 
 
 def align_measures(schedules: Iterable[ScheduleComponent],

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -21,17 +21,14 @@ import abc
 import itertools
 import multiprocessing as mp
 import sys
-from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional, Type, TYPE_CHECKING
+from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional, Type
 import warnings
 
 from qiskit.util import is_main_process
-from .timeslots import Interval
+from .timeslots import Interval, TimeslotCollection
 from .channels import Channel
 from .interfaces import ScheduleComponent
-from .timeslots import TimeslotCollection
 from .exceptions import PulseError
-if TYPE_CHECKING:
-    from qiskit.visualization.pulse.qcstyle import SchedStyle
 
 # pylint: disable=missing-return-doc
 
@@ -384,26 +381,26 @@ class Schedule(ScheduleComponent):
              framechange: bool = True, scaling: float = None,
              channels: Optional[List[Channel]] = None,
              show_framechange_channels: bool = True):
-        """Plot the schedule.
+        r"""Plot the schedule.
 
         Args:
-            dt: Time interval of samples
-            style: A style sheet to configure plot appearance
-            filename: Name required to save pulse image
-            interp_method: A function for interpolation
+            dt: Time interval of samples.
+            style: A style sheet to configure plot appearance.
+            filename: Name required to save pulse image.
+            interp_method: A function for interpolation.
             scale: Relative visual scaling of waveform amplitudes, see Additional Information.
             channel_scales: Channel independent scaling as a dictionary of ``Channel`` object.
-            channels_to_plot: Deprecated, see ``channels``
-            plot_all: Plot empty channels
-            plot_range: A tuple of time range to plot
+            channels_to_plot: Deprecated, see ``channels``.
+            plot_all: Plot empty channels.
+            plot_range: A tuple of time range to plot.
             interactive: When set true show the circuit in a new window
-                         (this depends on the matplotlib backend being used supporting this)
-            table: Draw event table for supported commands
-            label: Label individual instructions
-            framechange: Add framechange indicators
-            scaling: Deprecated, see ``scale``
-            channels: A list of channel names to plot
-            show_framechange_channels: Plot channels with only framechanges
+                         (this depends on the matplotlib backend being used supporting this).
+            table: Draw event table for supported commands.
+            label: Label individual instructions.
+            framechange: Add framechange indicators.
+            scaling: Deprecated, see ``scale``.
+            channels: A list of channel names to plot.
+            show_framechange_channels: Plot channels with only framechanges.
 
         Additional Information:
             If you want to manually rescale the waveform amplitude of channels one by one,
@@ -419,7 +416,7 @@ class Schedule(ScheduleComponent):
             The scaling factor is displayed under the channel name alias.
 
         Returns:
-            matplotlib.figure: A matplotlib figure object of the pulse schedule.
+            A matplotlib figure object of the pulse schedule.
         """
         # pylint: disable=invalid-name, cyclic-import
         if scaling is not None:

--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -32,9 +32,9 @@ from qiskit.visualization.pulse import interpolation
 from qiskit.pulse.channels import (DriveChannel, ControlChannel,
                                    MeasureChannel, AcquireChannel,
                                    SnapshotChannel)
+from qiskit.pulse.commands import FrameChangeInstruction
 from qiskit.pulse import (SamplePulse, FrameChange, PersistentValue, Snapshot,
                           Acquire, PulseError, ParametricPulse)
-from qiskit.pulse.commands.frame_change import FrameChangeInstruction
 
 
 class EventsOutputChannels:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed most of the Pulse module issues warnings 
```
/Users/sooluthomas/Documents/qiskit-terra/qiskit/pulse/schedule.py:docstring of qiskit.pulse.Schedule.draw:45: WARNING: Inline literal start-string without end-string.
```

### Details and comments


