### PR TITLE
Fix all sphinx warnings

### DIFF
--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -90,7 +90,7 @@ class Initialize(Instruction):
         """Call to create a circuit with gates that take the desired vector to zero.
 
         Returns:
-            QuantumCircuit: circuit to take self.params vector to :math:`\ket{00\ldots0}`
+            QuantumCircuit: circuit to take self.params vector to :math:`|{00\\ldots0}\\rangle`
         """
         q = QuantumRegister(self.num_qubits)
         circuit = QuantumCircuit(q, name='disentangler')

--- a/qiskit/extensions/standard/h.py
+++ b/qiskit/extensions/standard/h.py
@@ -168,9 +168,9 @@ def ch(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
     """Apply cH gate
 
     From a specified control ``control_qubit`` to target ``target_qubit`` qubit.
-    This gate is canonically used to rotate the qubit state from :math:`\ket{0}` to
-    :math:`\ket{+}` and :math:`\ket{1} to :math:`\ket{−}` when the control qubit is
-    in state :math:`\ket{1}`.
+    This gate is canonically used to rotate the qubit state from :math:`|0\\rangle` to
+    :math:`|+\\rangle` and :math:`|1\\rangle to :math:`|−\\rangle` when the control qubit is
+    in state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/extensions/standard/i.py
+++ b/qiskit/extensions/standard/i.py
@@ -69,8 +69,8 @@ def i(self, qubit, *, q=None):  # pylint: disable=unused-argument
     """Apply Identity to to a specified qubit ``qubit``.
 
     The Identity gate ensures that nothing is applied to a qubit for one unit
-    of gate time. It leaves the quantum states :math:`\ket{0}` and
-    :math:`\ket{1}` unchanged. The Identity gate should not be optimized or
+    of gate time. It leaves the quantum states :math:`|0\\rangle` and
+    :math:`|1\\rangle` unchanged. The Identity gate should not be optimized or
     unrolled (it is an opaque gate).
 
     Examples:

--- a/qiskit/extensions/standard/rz.py
+++ b/qiskit/extensions/standard/rz.py
@@ -71,7 +71,7 @@ class RZGate(Gate):
 
 @deprecate_arguments({'q': 'qubit'})
 def rz(self, phi, qubit, *, q=None):  # pylint: disable=invalid-name,unused-argument
-    """Apply Rz gate with angle :math:`\phi`
+    """Apply Rz gate with angle :math:`\\phi`
 
     The gate is applied to a specified qubit `qubit`.
     An Rz gate implemements a phi radian rotation of the qubit state vector
@@ -158,9 +158,9 @@ def crz(self, theta, control_qubit, target_qubit,
     """Apply cRz gate
 
     Applied from a specified control ``control_qubit`` to target ``target_qubit`` qubit
-    with angle :math:`\theta`. A cRz gate implements a :math:`\theta` radian rotation
+    with angle :math:`\\theta`. A cRz gate implements a :math:`\\theta` radian rotation
     of the qubit state vector about the z axis of the Bloch sphere when the control
-    qubit is in state :math:`\ket{1}`.
+    qubit is in state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/extensions/standard/swap.py
+++ b/qiskit/extensions/standard/swap.py
@@ -182,7 +182,7 @@ def cswap(self, control_qubit, target_qubit1, target_qubit2,
     From a specified control ``control_qubit`` to target1 ``target_qubit1`` and
     target2 ``target_qubit2`` qubits. The CSWAP gate is canonically
     used to swap the qubit states of target1 and target2 when the control qubit
-    is in state :math:`\ket{1}`.
+    is in state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/extensions/standard/u1.py
+++ b/qiskit/extensions/standard/u1.py
@@ -76,7 +76,7 @@ def u1(self, theta, qubit, *, q=None):  # pylint: disable=invalid-name,unused-ar
     """Apply U1 gate with angle theta
 
     Applied to a specified qubit ``qubit``.
-    :math:`u1(\lambda) := diag(1, ei\lambda) ∼ U(0, 0, \lambda) = Rz(\lambda)`
+    :math:`u1(\\lambda) := diag(1, ei\\lambda) ∼ U(0, 0, \\lambda) = Rz(\\lambda)`
     where :math:`~` is equivalence up to a global phase.
 
     Examples:

--- a/qiskit/extensions/standard/u3.py
+++ b/qiskit/extensions/standard/u3.py
@@ -178,7 +178,7 @@ def cu3(self, theta, phi, lam, control_qubit, target_qubit,
     Applied from a specified control ``control_qubit`` to target
     ``target_qubit`` qubit with angle ``theta``, ``phi``, and ``lam``.
     A cU3 gate implements a ``U3(theta,phi,lam)`` on the target qubit when the
-    control qubit is in state :math:`\ket{1}`.
+    control qubit is in state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -84,9 +84,9 @@ class XGate(Gate):
 def x(self, qubit, *, q=None):  # pylint: disable=unused-argument
     """Apply X gate to a specified qubit (qubit).
 
-    An X gate implements a :math:`\pi` rotation of the qubit state vector about
+    An X gate implements a :math:`\\pi` rotation of the qubit state vector about
     the x axis of the Bloch sphere. This gate is canonically used to implement
-    a bit flip on the qubit state from :math:`\ket{0}` to :math:`\ket{1}`,
+    a bit flip on the qubit state from :math:`|0\\rangle` to :math:`|1\\rangle`,
     or vice versa.
 
     Examples:
@@ -181,11 +181,11 @@ def cx(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
     """Apply CX gate
 
     From a specified control ``control_qubit`` to target ``target_qubit`` qubit.
-    A CX gate implements a :math:`\pi` rotation of the qubit state vector about
-    the x axis of the Bloch sphere when the control qubit is in state :math:`\ket{1}`
+    A CX gate implements a :math:`\\pi` rotation of the qubit state vector about
+    the x axis of the Bloch sphere when the control qubit is in state :math:`|1\\rangle`
     This gate is canonically used to implement a bit flip on the qubit state from
-    :math:`\ket{0}` to :math:`\ket{1}`, or vice versa when the control qubit is in
-    :math:`\ket{1}`.
+    :math:`|0\\rangle` to :math:`|1\\rangle`, or vice versa when the control qubit is in
+    :math:`|1\\rangle`.
 
     Examples:
 
@@ -300,8 +300,8 @@ def ccx(self, control_qubit1, control_qubit2, target_qubit,
     """Apply Toffoli (ccX) gate
 
     From two specified controls ``(control_qubit1 and control_qubit2)`` to target ``target_qubit``
-    qubit. This gate is canonically used to rotate the qubit state from :math:`\ket{0}` to
-    :math:`\ket{1}`, or vice versa when both the control qubits are in state :math:`\ket{1}`.
+    qubit. This gate is canonically used to rotate the qubit state from :math:`|0\\rangle` to
+    :math:`|1\\rangle`, or vice versa when both the control qubits are in state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/extensions/standard/y.py
+++ b/qiskit/extensions/standard/y.py
@@ -74,10 +74,10 @@ class YGate(Gate):
 def y(self, qubit, *, q=None):  # pylint: disable=unused-argument
     """Apply Y gate to a specified qubit (qubit).
 
-    A Y gate implements a :math:`\pi` rotation of the qubit state vector about
+    A Y gate implements a :math:`\\pi` rotation of the qubit state vector about
     the y axis of the Bloch sphere. This gate is canonically used to implement
-    a bit flip and phase flip on the qubit state from :math:`\ket{0}` to
-    :math:`i\ket{1}`, or from :math:`\ket{1}` to :math:`-i\ket{0}`.
+    a bit flip and phase flip on the qubit state from :math:`|0\\rangle` to
+    :math:`i|1\\rangle`, or from :math:`|1\\rangle` to :math:`-i|0\\rangle`.
 
     Examples:
 
@@ -172,10 +172,10 @@ def cy(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
 
     Applied from a specified control ``control_qubit`` to target ``target_qubit`` qubit.
     A cY gate implements a pi rotation of the qubit state vector about the y axis
-    of the Bloch sphere when the control qubit is in state :math:`\ket{1}`.
+    of the Bloch sphere when the control qubit is in state :math:`|1\\rangle`.
     This gate is canonically used to implement a bit flip and phase flip on the qubit state
-    from :math:`\ket{0}` to :math:`i\ket{1}`, or from :math:`\ket{1}` to :math:`-i\ket{0}`
-    when the control qubit is in state :math:`\ket{1}`.
+    from :math:`|0\\rangle` to :math:`i|1\\rangle`, or from :math:`|1\\rangle` to
+    :math:`-i|0\\rangle` when the control qubit is in state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/extensions/standard/z.py
+++ b/qiskit/extensions/standard/z.py
@@ -74,9 +74,9 @@ class ZGate(Gate):
 def z(self, qubit, *, q=None):  # pylint: disable=unused-argument
     """Apply Z gate to a specified qubit (qubit).
 
-    A Z gate implements a :math:`\pi` rotation of the qubit state vector about
+    A Z gate implements a :math:`\\pi` rotation of the qubit state vector about
     the z axis of the Bloch sphere. This gate is canonically used to implement
-    a phase flip on the qubit state from :math:`\ket{+}` to :math:`\ket{-}`,
+    a phase flip on the qubit state from :math:`|+\\rangle` to :math:`|-\\rangle`,
     or vice versa.
 
     Examples:
@@ -170,11 +170,11 @@ def cz(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
     """Apply cZ gate
 
     From a specified control ``control_qubit`` to target ``target_qubit`` qubit.
-    A cZ gate implements a :math:`\pi` rotation of the qubit state vector about
-    the z axis of the Bloch sphere when the control qubit is in state :math:`\ket{1}`.
+    A cZ gate implements a :math:`\\pi` rotation of the qubit state vector about
+    the z axis of the Bloch sphere when the control qubit is in state :math:`|1\\rangle`.
     This gate is canonically used to implement a phase flip on the qubit state from
-    :math:`\ket{+}` to :math:`\ket{-}`, or vice versa when the control qubit is in
-    state :math:`\ket{1}`.
+    :math:`|+\\rangle` to :math:`|-\\rangle`, or vice versa when the control qubit is in
+    state :math:`|1\\rangle`.
 
     Examples:
 

--- a/qiskit/pulse/commands/parametric_pulses.py
+++ b/qiskit/pulse/commands/parametric_pulses.py
@@ -96,7 +96,7 @@ class ParametricPulse(PulseCommand):
         return ParametricInstruction(self, channel, name=name)
 
     def draw(self, dt: float = 1,
-             style = None,
+             style=None,
              filename: Optional[str] = None,
              interp_method: Optional[Callable] = None,
              scale: float = 1, interactive: bool = False,

--- a/qiskit/pulse/commands/pulse_command.py
+++ b/qiskit/pulse/commands/pulse_command.py
@@ -37,7 +37,7 @@ class PulseCommand(Command):
 
     @abstractmethod
     def draw(self, dt: float = 1,
-             style = None,
+             style=None,
              filename: Optional[str] = None,
              interp_method: Optional[Callable] = None,
              scale: float = 1, interactive: bool = False,

--- a/qiskit/pulse/commands/sample_pulse.py
+++ b/qiskit/pulse/commands/sample_pulse.py
@@ -100,7 +100,7 @@ class SamplePulse(PulseCommand):
         return samples
 
     def draw(self, dt: float = 1,
-             style = None,
+             style=None,
              filename: Optional[str] = None,
              interp_method: Optional[Callable] = None,
              scale: float = 1, interactive: bool = False,

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -200,7 +200,7 @@ class Instruction(ScheduleComponent, ABC):
         time = self.ch_stop_time(*common_channels)
         return self.insert(time, schedule, name=name)
 
-    def draw(self, dt: float = 1, style = None,
+    def draw(self, dt: float = 1, style=None,
              filename: Optional[str] = None, interp_method: Optional[Callable] = None,
              scale: float = 1, channels_to_plot: Optional[List[Channel]] = None,
              plot_all: bool = False, plot_range: Optional[Tuple[float]] = None,

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -33,7 +33,7 @@ from qiskit.pulse.channels import Channel
 from qiskit.pulse.timeslots import Interval, Timeslot, TimeslotCollection
 from ..interfaces import ScheduleComponent
 from ..schedule import Schedule
-from .. import commands
+from .. import commands  # pylint: disable=unused-import
 
 # pylint: disable=missing-return-doc
 

--- a/qiskit/pulse/pulse_lib/discrete.py
+++ b/qiskit/pulse/pulse_lib/discrete.py
@@ -21,9 +21,9 @@ Note the sampling strategy use for all discrete pulses is `midpoint`.
 import warnings
 from typing import Optional
 
+from qiskit.pulse.exceptions import PulseError
 from ..commands import SamplePulse
 from . import continuous
-from qiskit.pulse.exceptions import PulseError
 
 from . import samplers
 

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -21,7 +21,7 @@ import abc
 import itertools
 import multiprocessing as mp
 import sys
-from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional, Type
+from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional
 import warnings
 
 from qiskit.util import is_main_process
@@ -167,11 +167,9 @@ class Schedule(ScheduleComponent):
             time: Shifted time due to parent.
 
         Yields:
-            Tuple containing the time each :class:`~qiskit.pulse.Instruction`
-            starts at and the flattened :class:`~qiskit.pulse.Instruction` s.
-
-        ReturnType:
-            Iterable[Tuple[int, Instruction]]
+            Iterable[Tuple[int, Instruction]]: Tuple containing the time each
+                :class:`~qiskit.pulse.Instruction`
+                starts at and the flattened :class:`~qiskit.pulse.Instruction` s.
         """
         for insert_time, child_sched in self._children:
             yield from child_sched._instructions(time + insert_time)
@@ -441,7 +439,7 @@ class Schedule(ScheduleComponent):
             The scaling factor is displayed under the channel name alias.
 
         Returns:
-            A matplotlib figure object of the pulse schedule.
+            matplotlib.Figure: A matplotlib figure object of the pulse schedule.
         """
         # pylint: disable=invalid-name, cyclic-import
         if scaling is not None:

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -258,7 +258,7 @@ class Schedule(ScheduleComponent):
 
     def filter(self, *filter_funcs: List[Callable],
                channels: Optional[Iterable[Channel]] = None,
-               instruction_types = None,
+               instruction_types=None,
                time_ranges: Optional[Iterable[Tuple[int, int]]] = None,
                intervals: Optional[Iterable[Interval]] = None) -> 'Schedule':
         """Return a new ``Schedule`` with only the instructions from this ``Schedule`` which pass
@@ -289,7 +289,7 @@ class Schedule(ScheduleComponent):
 
     def exclude(self, *filter_funcs: List[Callable],
                 channels: Optional[Iterable[Channel]] = None,
-                instruction_types = None,
+                instruction_types=None,
                 time_ranges: Optional[Iterable[Tuple[int, int]]] = None,
                 intervals: Optional[Iterable[Interval]] = None) -> 'Schedule':
         """Return a Schedule with only the instructions from this Schedule *failing* at least one
@@ -328,7 +328,7 @@ class Schedule(ScheduleComponent):
 
     def _construct_filter(self, *filter_funcs: List[Callable],
                           channels: Optional[Iterable[Channel]] = None,
-                          instruction_types = None,
+                          instruction_types=None,
                           time_ranges: Optional[Iterable[Tuple[int, int]]] = None,
                           intervals: Optional[Iterable[Interval]] = None) -> Callable:
         """Returns a boolean-valued function with input type ``(int, ScheduleComponent)`` that
@@ -396,7 +396,7 @@ class Schedule(ScheduleComponent):
         # return function returning true iff all filters are passed
         return lambda x: all([filter_func(x) for filter_func in filter_func_list])
 
-    def draw(self, dt: float = 1, style = None,
+    def draw(self, dt: float = 1, style=None,
              filename: Optional[str] = None, interp_method: Optional[Callable] = None,
              scale: Optional[float] = None,
              channel_scales: Optional[Dict[Channel, float]] = None,
@@ -436,7 +436,7 @@ class Schedule(ScheduleComponent):
                                   pulse.MeasureChannels(0): 5.0}
 
             When the channel to plot is not included in the ``channel_scales`` dictionary,
-            scaling factor of that channel is overwritten by the value of ``scale` argument.
+            scaling factor of that channel is overwritten by the value of ``scale`` argument.
             In default, waveform amplitude is normalized by the maximum amplitude of the channel.
             The scaling factor is displayed under the channel name alias.
 

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -259,7 +259,7 @@ class DensityMatrix(QuantumState):
     def from_instruction(cls, instruction):
         """Return the output density matrix of an instruction.
 
-        The statevector is initialized in the state :math:`\ket{0,\ldots,0}` of
+        The statevector is initialized in the state :math:`|{0,\\ldots,0}\\rangle` of
         the same number of qubits as the input instruction or circuit, evolved
         by the input instruction, and the output statevector returned.
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -326,7 +326,7 @@ class Statevector(QuantumState):
     def from_instruction(cls, instruction):
         """Return the output statevector of an instruction.
 
-        The statevector is initialized in the state :math:\ket{0,\ldots,0} of the
+        The statevector is initialized in the state :math:`|{0,\\ldots,0}\\rangle` of the
         same number of qubits as the input instruction or circuit, evolved
         by the input instruction, and the output statevector returned.
 

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -350,8 +350,8 @@ class TwoQubitBasisDecomposer():
                                   self.decomp3_supercontrolled]
 
     def traces(self, target):
-        """Give the expected traces :math:`|Tr(U \\cdot Utarget^dag)|`for different number of
-        basis gates"""
+        """Give the expected traces :math:`|Tr(U \\cdot Utarget^dag)|` for different number of
+        basis gates."""
         # Future gotcha: extending this to non-supercontrolled basis.
         # Careful: closest distance between a1,b1,c1 and a2,b2,c2 may be between reflections.
         # This doesn't come up if either c1==0 or c2==0 but otherwise be careful.

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -261,7 +261,7 @@ def Ud(a, b, c):
 
 
 def trace_to_fid(trace):
-    """Average gate fidelity is :math:`Fbar = (d + |Tr (Utarget \cdot U^dag)|^2) / d(d+1)`
+    """Average gate fidelity is :math:`Fbar = (d + |Tr (Utarget \\cdot U^dag)|^2) / d(d+1)`
     M. Horodecki, P. Horodecki and R. Horodecki, PRA 60, 1888 (1999)"""
     return (4 + np.abs(trace)**2)/20
 
@@ -350,7 +350,8 @@ class TwoQubitBasisDecomposer():
                                   self.decomp3_supercontrolled]
 
     def traces(self, target):
-        """Give the expected traces :math:`|Tr(U \cdot Utarget^dag)|` for different number of basis gates"""
+        """Give the expected traces :math:`|Tr(U \\cdot Utarget^dag)|`for different number of
+        basis gates"""
         # Future gotcha: extending this to non-supercontrolled basis.
         # Careful: closest distance between a1,b1,c1 and a2,b2,c2 may be between reflections.
         # This doesn't come up if either c1==0 or c2==0 but otherwise be careful.

--- a/qiskit/scheduler/utils.py
+++ b/qiskit/scheduler/utils.py
@@ -57,7 +57,8 @@ def measure(qubits: List[int],
 
     Args:
         qubits: List of qubits to be measured.
-        backend: A backend instance, which contains hardware-specific data required for scheduling.
+        backend (BaseBackend): A backend instance, which contains hardware-specific data
+            required for scheduling.
         inst_map: Mapping of circuit operations to pulse schedules. If None, defaults to the
                   ``instruction_schedule_map`` of ``backend``.
         meas_map: List of sets of qubits that must be measured together. If None, defaults to
@@ -118,7 +119,8 @@ def measure_all(backend) -> Schedule:
     Return a Schedule which measures all qubits of the given backend.
 
     Args:
-        backend: A backend instance, which contains hardware-specific data required for scheduling.
+        backend (BaseBackend): A backend instance, which contains hardware-specific data
+            required for scheduling.
 
     Returns:
         A schedule corresponding to the inputs provided.

--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -272,14 +272,16 @@ def choi_to_pauli(choi, order=1):
     Note that this function assumes that the Choi-matrix
     is defined in the standard column-stacking convention
     and is normalized to have trace 1. For a channel E this
-    is defined as: :math:`choi = (I \otimes E)(bell_state)`.
+    is defined as: :math:`choi = (I \\otimes E)(bell_state)`.
 
-    The resulting 'rauli' R acts on input states as .. math::
+    The resulting 'rauli' R acts on input states as
 
-        \ket{rho_out}_p = R \cdot \ket{rho_in}_p
+    .. math::
 
-    where :math:`\ket{rho} =` ``vectorize(rho, method='pauli')`` for order=1
-    and :math:`\ket{rho} =` ``vectorize(rho, method='pauli_weights')`` for order=0.
+        |{\\rho_{out}}_p\\rangle = R \\cdot |{\\rho_{in}}_p\\rangle.
+
+    where :math:`|{\\rho}\\rangle =` ``vectorize(rho, method='pauli')`` for order=1
+    and :math:`|{\\rho}\\rangle =` ``vectorize(rho, method='pauli_weights')`` for order=0.
 
     Args:
         choi (matrix): the input Choi-matrix.
@@ -347,7 +349,7 @@ def outer(vector1, vector2=None):
         vector2 (ndarray): the (optional) second vector.
 
     Returns:
-        np.array: The matrix :math:`\ket{v1}\bra{v2}`.
+        np.array: The matrix :math:`|v1\\rangle\\langle{v2}|`.
 
     """
     warnings.warn(

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -291,8 +291,9 @@ class PassManager:
             raw (bool): If ``True``, save the raw Dot output instead of the image.
 
         Returns:
-            an in-memory representation of the pass manager, or ``None`` if no image was generated
-            or `Pillow <https://pypi.org/project/Pillow/>`_ is not installed.
+            Optional[PassManager]: an in-memory representation of the pass manager, or ``None``
+            if no image was generated or `Pillow <https://pypi.org/project/Pillow/>`__
+            is not installed.
 
         Raises:
             ImportError: when nxpd or pydot not installed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Fixed almost all lint except :

#### Lint 

```
************* Module qiskit.tools.jupyter.job_watcher
qiskit/tools/jupyter/job_watcher.py:21:0: E0611: No name 'ibmq' in module 'qiskit.providers' (no-name-in-module)
qiskit/tools/jupyter/job_watcher.py:21:0: E0401: Unable to import 'qiskit.providers.ibmq.job.exceptions' (import-error)
************* Module test.randomized.__init__
test/randomized/__init__.py:1:0: R0401: Cyclic import (qiskit.pulse.commands -> qiskit.pulse.commands.parametric_pulses -> qiskit.pulse.pulse_lib -> qiskit.pulse.pulse_lib.discrete) (cyclic-import)
test/randomized/__init__.py:1:0: R0401: Cyclic import (qiskit.pulse -> qiskit.pulse.cmd_def -> qiskit.qobj.converters -> qiskit.qobj.converters.pulse_instruction -> qiskit.pulse.commands -> qiskit.pulse.commands.acquire) (cyclic-import)
```

#### Warnings 

```
/Users/sooluthomas/Documents/qiskit-terra/docs/release_notes.rst:1499: WARNING: Inline literal start-string without end-string.
/Users/sooluthomas/Documents/qiskit-terra/docs/release_notes.rst:1499: WARNING: Inline literal start-string without end-string.
WARNING: Cell printed to stderr:
/Users/sooluthomas/Documents/qiskit-terra/.tox/docs/lib/python3.7/site-packages/numpy/core/_asarray.py:85: ComplexWarning: Casting complex values to real discards the imaginary part
  return array(a, dtype, copy=False, order=order)

WARNING: Cell printed to stderr:
/Users/sooluthomas/Documents/qiskit-terra/.tox/docs/lib/python3.7/site-packages/numpy/core/_asarray.py:85: ComplexWarning: Casting complex values to real discards the imaginary part
  return array(a, dtype, copy=False, order=order)
```

```
/Users/sooluthomas/Documents/qiskit-terra/qiskit/circuit/quantumcircuit.py:docstring of qiskit.circuit.QuantumCircuit.append:: WARNING: more than one target found for cross-reference 'Instruction': qiskit.circuit.Instruction, qiskit.pulse.Instruction
/Users/sooluthomas/Documents/qiskit-terra/qiskit/pulse/schedule.py:docstring of qiskit.pulse.Schedule.exclude:: WARNING: more than one target found for cross-reference 'Instruction': qiskit.circuit.Instruction, qiskit.pulse.Instruction
/Users/sooluthomas/Documents/qiskit-terra/qiskit/pulse/schedule.py:docstring of qiskit.pulse.Schedule.filter:: WARNING: more than one target found for cross-reference 'Instruction': qiskit.circuit.Instruction, qiskit.pulse.Instruction
```
