### PR TITLE
some follow up on https://github.com/Qiskit/qiskit-terra/pull/10530

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # Qiskit
-[![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)<!--- long-description-skip-begin -->[![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?style=popout-square)](https://github.com/Qiskit/qiskit-terra/releases)[![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg?style=popout-square)](https://pypi.org/project/qiskit-terra/)[![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)[![Minimum rustc 1.64.0](https://img.shields.io/badge/rustc-1.64.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)<!--- long-description-skip-end -->
+[![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?)](https://opensource.org/licenses/Apache-2.0) [![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg)]
+(https://github.com/Qiskit/qiskit-terra/releases)[![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg)](https://pypi.org/project/qiskit-terra/)
+[![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
+[![Minimum rustc 1.64.0](https://img.shields.io/badge/rustc-1.64.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![Downloads](https://pepy.tech/badge/qiskit-terra)](https://pypi.org/project/qiskit-terra/)
+[![DOI](https://zenodo.org/badge/161550823.svg)](https://zenodo.org/badge/latestdoi/161550823)
 
 **Qiskit** is an open-source framework for working with noisy quantum computers at the level of pulses, circuits, and algorithms.
 
-This Qiskit contains the building blocks for creating and working with quantum circuits, programs, and algorithms. It also
-contains a compiler that supports different quantum computers and a common interface for running programs on different quantum
-computer architectures.
+This framework allows for building, transforming, and visualizing  quantum circuits. It also contains a compiler that supports
+different quantum computers and a common interface for running programs on different quantum computer architectures.
 
 For more details on how to use Qiskit you can refer to the documentation located here:
 
-https://qiskit.org/documentation/
+<https://qiskit.org/documentation/>
 
 
 ## Installation
 
-We encourage installing Qiskit via ``pip``.
+We encourage installing Qiskit via ``pip``:
 
 ```bash
 pip install qiskit
@@ -37,7 +42,7 @@ qc.cx(0, 1)
 qc.measure([0,1], [0,1])
 ```
 
-This simple example makes an entangled state, also called a [Bell state](https://qiskit.org/textbook/ch-gates/multiple-qubits-entangled-states.html#3.2-Entangled-States-).
+This example makes an entangled state, also called a [Bell state](https://en.wikipedia.org/wiki/Bell_state).
 
 Once you've made your first quantum circuit, you can then simulate it.
 To do this, first we need to compile your circuit for the target backend we're going to run
@@ -66,12 +71,9 @@ The output from this execution will look similar to this:
 {'00': 513, '11': 511}
 ```
 
-For further examples of using Qiskit you can look at the example scripts in **examples/python**. You can start with
-[using_qiskit_terra_level_0.py](examples/python/using_qiskit_terra_level_0.py) and working up in the levels. Also
-you can refer to the tutorials in the documentation here:
+For further examples of using Qiskit you can look at the tutorials in the documentation here:
 
-https://qiskit.org/documentation/tutorials.html
-
+<https://qiskit.org/documentation/tutorials.html>
 
 ### Executing your code on a real quantum chip
 
@@ -95,21 +97,17 @@ on how to get access and use these systems.
 ## Contribution Guidelines
 
 If you'd like to contribute to Qiskit, please take a look at our
-[contribution guidelines](CONTRIBUTING.md). This project adheres to Qiskit's [code of conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+[contribution guidelines](CONTRIBUTING.md). By participating, you are expected to uphold our [code of conduct](CODE_OF_CONDUCT.md).
 
 We use [GitHub issues](https://github.com/Qiskit/qiskit-terra/issues) for tracking requests and bugs. Please
-[join the Qiskit Slack community](https://qisk.it/join-slack)
-and use our [Qiskit Slack channel](https://qiskit.slack.com) for discussion and simple questions.
-For questions that are more suited for a forum we use the `qiskit` tag in the [Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/qiskit).
+[join the Qiskit Slack community](https://qisk.it/join-slack) for discussion, comments, and questions.
+For questions related to running or using Qiskit, [Stack Overflow has a `qiskit`](https://stackoverflow.com/questions/tagged/qiskit).
+For questions on quantum computing with Qiskit, use the `qiskit` tag in the [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/qiskit) (please, read first the [guidelines on how to ask](https://quantumcomputing.stackexchange.com/help/how-to-ask) in that forum).
 
-## Next Steps
-
-Now you're set up and ready to check out some of the other examples from our
-[Qiskit Tutorials](https://github.com/Qiskit/qiskit-tutorials) repository.
 
 ## Authors and Citation
 
-Qiskit is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
+Qiskit Terra is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
 to the project at different levels. If you use Qiskit, please cite as per the included [BibTeX file](CITATION.bib).
 
 ## Changelog and Release Notes
@@ -118,10 +116,10 @@ The changelog for a particular release is dynamically generated and gets
 written to the release page on Github for each release. For example, you can
 find the page for the `0.9.0` release here:
 
-https://github.com/Qiskit/qiskit-terra/releases/tag/0.9.0
+<https://github.com/Qiskit/qiskit-terra/releases/tag/0.9.0>
 
 The changelog for the current release can be found in the releases tab:
-[![Releases](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?style=popout-square)](https://github.com/Qiskit/qiskit-terra/releases)
+[![Releases](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg?style=flat&label=)](https://github.com/Qiskit/qiskit-terra/releases)
 The changelog provides a quick overview of notable changes for a given
 release.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Qiskit
-[![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?)](https://opensource.org/licenses/Apache-2.0)
-<!--- long-description-skip-begin -->
+[![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?)](https://opensource.org/licenses/Apache-2.0) <!--- long-description-skip-begin -->
 [![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg)](https://github.com/Qiskit/qiskit-terra/releases)
 [![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg)](https://pypi.org/project/qiskit-terra/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
 [![Minimum rustc 1.64.0](https://img.shields.io/badge/rustc-1.64.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Downloads](https://pepy.tech/badge/qiskit-terra)](https://pypi.org/project/qiskit-terra/)
-<!--- long-description-skip-end -->
-[![DOI](https://zenodo.org/badge/161550823.svg)](https://zenodo.org/badge/latestdoi/161550823)
+<!--- long-description-skip-end --> [![DOI](https://zenodo.org/badge/161550823.svg)](https://zenodo.org/badge/latestdoi/161550823)
 
 **Qiskit** is an open-source framework for working with noisy quantum computers at the level of pulses, circuits, and algorithms.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Qiskit
 [![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?)](https://opensource.org/licenses/Apache-2.0)
+<!--- long-description-skip-begin -->
 [![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg)](https://github.com/Qiskit/qiskit-terra/releases)
 [![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg)](https://pypi.org/project/qiskit-terra/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
 [![Minimum rustc 1.64.0](https://img.shields.io/badge/rustc-1.64.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Downloads](https://pepy.tech/badge/qiskit-terra)](https://pypi.org/project/qiskit-terra/)
+<!--- long-description-skip-end -->
 [![DOI](https://zenodo.org/badge/161550823.svg)](https://zenodo.org/badge/latestdoi/161550823)
 
 **Qiskit** is an open-source framework for working with noisy quantum computers at the level of pulses, circuits, and algorithms.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Qiskit
-[![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?)](https://opensource.org/licenses/Apache-2.0) [![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg)]
-(https://github.com/Qiskit/qiskit-terra/releases)[![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg)](https://pypi.org/project/qiskit-terra/)
+[![License](https://img.shields.io/github/license/Qiskit/qiskit-terra.svg?)](https://opensource.org/licenses/Apache-2.0)
+[![Release](https://img.shields.io/github/release/Qiskit/qiskit-terra.svg)](https://github.com/Qiskit/qiskit-terra/releases)
+[![Downloads](https://img.shields.io/pypi/dm/qiskit-terra.svg)](https://pypi.org/project/qiskit-terra/)
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
 [![Minimum rustc 1.64.0](https://img.shields.io/badge/rustc-1.64.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/Qiskit/qiskit-terra/badge.svg?branch=main)](https://coveralls.io/github/Qiskit/qiskit-terra?branch=main)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/qiskit)
 [![Minimum rustc 1.64.0](https://img.shields.io/badge/rustc-1.64.0+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
-[![Downloads](https://pepy.tech/badge/qiskit-terra)](https://pypi.org/project/qiskit-terra/)
-<!--- long-description-skip-end --> [![DOI](https://zenodo.org/badge/161550823.svg)](https://zenodo.org/badge/latestdoi/161550823)
+[![Downloads](https://pepy.tech/badge/qiskit-terra)](https://pypi.org/project/qiskit-terra/)<!--- long-description-skip-end -->
+[![DOI](https://zenodo.org/badge/161550823.svg)](https://zenodo.org/badge/latestdoi/161550823)
 
 **Qiskit** is an open-source framework for working with noisy quantum computers at the level of pulses, circuits, and algorithms.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For questions on quantum computing with Qiskit, use the `qiskit` tag in the [Qua
 
 ## Authors and Citation
 
-Qiskit Terra is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
+Qiskit is the work of [many people](https://github.com/Qiskit/qiskit-terra/graphs/contributors) who contribute
 to the project at different levels. If you use Qiskit, please cite as per the included [BibTeX file](CITATION.bib).
 
 ## Changelog and Release Notes


### PR DESCRIPTION
some follow up on https://github.com/Qiskit/qiskit-terra/pull/10530

 * extend some badges
 * `This Qiskit contains the building blocks for creating and working with quantum circuits, programs, and algorithms.` -> `This framework allows for building, transforming, and visualizing quantum circuits.`
 * The explanation of the Bell state is moving to IBM Quantun learning platform
 * I think `examples/` should eventually be replaced by proper tutorials
 * Add StackOverflow as a forum
 * Remove link to https://github.com/Qiskit/qiskit-tutorials