### PR TITLE
Define constants for readability and bug finding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1131,12 @@ name = "qiskit-circuit"
 version = "1.2.0"
 dependencies = [
  "hashbrown 0.14.5",
+ "lazy_static",
+ "ndarray",
+ "num-complex",
+ "numpy",
  "pyo3",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ license = "Apache-2.0"
 [workspace.dependencies]
 indexmap.version = "2.2.6"
 hashbrown.version = "0.14.0"
+num-complex = "0.4"
+ndarray = "^0.15.6"
+numpy = "0.21.0"
+smallvec = "1.13"
+
 # Most of the crates don't need the feature `extension-module`, since only `qiskit-pyext` builds an
 # actual C extension (the feature disables linking in `libpython`, which is forbidden in Python
 # distributions).  We only activate that feature when building the C extension module; we still need

--- a/crates/accelerate/Cargo.toml
+++ b/crates/accelerate/Cargo.toml
@@ -11,13 +11,13 @@ doctest = false
 
 [dependencies]
 rayon = "1.10"
-numpy = "0.21.0"
+numpy.workspace = true
 rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4.3"
 ahash = "0.8.11"
 num-traits = "0.2"
-num-complex = "0.4"
+num-complex.workspace = true
 num-bigint = "0.4"
 rustworkx-core = "0.14"
 faer = "0.18.2"
@@ -25,7 +25,7 @@ itertools = "0.12.1"
 qiskit-circuit.workspace = true
 
 [dependencies.smallvec]
-version = "1.13"
+workspace = true
 features = ["union"]
 
 [dependencies.pyo3]
@@ -33,7 +33,7 @@ workspace = true
 features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
 
 [dependencies.ndarray]
-version = "^0.15.6"
+workspace = true
 features = ["rayon", "approx-0_5"]
 
 [dependencies.approx]

--- a/crates/circuit/Cargo.toml
+++ b/crates/circuit/Cargo.toml
@@ -11,4 +11,15 @@ doctest = false
 
 [dependencies]
 hashbrown.workspace = true
-pyo3.workspace = true
+num-complex.workspace = true
+ndarray.workspace = true
+numpy.workspace = true
+lazy_static = "1.4"
+
+[dependencies.pyo3]
+workspace = true
+features = ["hashbrown", "indexmap", "num-complex", "num-bigint", "smallvec"]
+
+[dependencies.smallvec]
+workspace = true
+features = ["union"]

--- a/crates/circuit/src/circuit_instruction.rs
+++ b/crates/circuit/src/circuit_instruction.rs
@@ -10,10 +10,27 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use lazy_static::lazy_static;
+
+use hashbrown::HashMap;
 use pyo3::basic::CompareOp;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyList, PyTuple};
-use pyo3::{PyObject, PyResult};
+use pyo3::types::{IntoPyDict, PyList, PyTuple};
+use pyo3::{intern, IntoPy, PyObject, PyResult};
+use smallvec::SmallVec;
+use std::sync::Mutex;
+
+use crate::operations::{
+    Operation, OperationType, Param, PyGate, PyInstruction, PyOperation, StandardGate,
+    STANDARD_GATE_SIZE,
+};
+
+// TODO Come up with a better cacheing mechanism for this
+lazy_static! {
+    static ref STANDARD_GATE_MAP: Mutex<HashMap<StandardGate, PyObject>> =
+        Mutex::new(HashMap::with_capacity(STANDARD_GATE_SIZE));
+}
 
 /// A single instruction in a :class:`.QuantumCircuit`, comprised of the :attr:`operation` and
 /// various operands.
@@ -47,30 +64,52 @@ use pyo3::{PyObject, PyResult};
 ///     mutations of the object do not invalidate the types, nor the restrictions placed on it by
 ///     its context.  Typically this will mean, for example, that :attr:`qubits` must be a sequence
 ///     of distinct items, with no duplicates.
-#[pyclass(
-    freelist = 20,
-    sequence,
-    get_all,
-    module = "qiskit._accelerate.circuit"
-)]
+#[pyclass(freelist = 20, sequence, module = "qiskit._accelerate.circuit")]
 #[derive(Clone, Debug)]
 pub struct CircuitInstruction {
-    /// The logical operation that this instruction represents an execution of.
-    pub operation: PyObject,
+    pub operation: OperationType,
     /// A sequence of the qubits that the operation is applied to.
+    #[pyo3(get)]
     pub qubits: Py<PyTuple>,
     /// A sequence of the classical bits that this operation reads from or writes to.
+    #[pyo3(get)]
     pub clbits: Py<PyTuple>,
+    pub params: Option<SmallVec<[Param; 3]>>,
+    pub label: Option<String>,
+    pub duration: Option<PyObject>,
+    pub unit: Option<String>,
+    pub condition: Option<PyObject>,
+}
+
+/// This enum is for backwards compatibility if a user was doing something from
+/// Python like CircuitInstruction(SXGate(), [qr[0]], []) by passing a python
+/// gate object directly to a CircuitInstruction. In this case we need to
+/// create a rust side object from the pyobject in CircuitInstruction.new()
+/// With the `Object` variant which will convert the python object to a rust
+/// `OperationType`
+#[derive(FromPyObject, Debug)]
+pub enum OperationInput {
+    Standard(StandardGate),
+    Gate(PyGate),
+    Instruction(PyInstruction),
+    Operation(PyOperation),
+    Object(PyObject),
 }
 
 #[pymethods]
 impl CircuitInstruction {
+    #[allow(clippy::too_many_arguments)]
     #[new]
     pub fn new(
         py: Python<'_>,
-        operation: PyObject,
+        operation: OperationInput,
         qubits: Option<&Bound<PyAny>>,
         clbits: Option<&Bound<PyAny>>,
+        params: Option<SmallVec<[Param; 3]>>,
+        label: Option<String>,
+        duration: Option<PyObject>,
+        unit: Option<String>,
+        condition: Option<PyObject>,
     ) -> PyResult<Self> {
         fn as_tuple(py: Python<'_>, seq: Option<&Bound<PyAny>>) -> PyResult<Py<PyTuple>> {
             match seq {
@@ -95,11 +134,122 @@ impl CircuitInstruction {
             }
         }
 
-        Ok(CircuitInstruction {
-            operation,
-            qubits: as_tuple(py, qubits)?,
-            clbits: as_tuple(py, clbits)?,
-        })
+        match operation {
+            OperationInput::Standard(operation) => {
+                let operation = OperationType::Standard(operation);
+                Ok(CircuitInstruction {
+                    operation,
+                    qubits: as_tuple(py, qubits)?,
+                    clbits: as_tuple(py, clbits)?,
+                    params,
+                    label,
+                    duration,
+                    unit,
+                    condition,
+                })
+            }
+            OperationInput::Gate(operation) => {
+                let operation = OperationType::Gate(operation);
+                Ok(CircuitInstruction {
+                    operation,
+                    qubits: as_tuple(py, qubits)?,
+                    clbits: as_tuple(py, clbits)?,
+                    params,
+                    label,
+                    duration,
+                    unit,
+                    condition,
+                })
+            }
+            OperationInput::Instruction(operation) => {
+                let operation = OperationType::Instruction(operation);
+                Ok(CircuitInstruction {
+                    operation,
+                    qubits: as_tuple(py, qubits)?,
+                    clbits: as_tuple(py, clbits)?,
+                    params,
+                    label,
+                    duration,
+                    unit,
+                    condition,
+                })
+            }
+            OperationInput::Operation(operation) => {
+                let operation = OperationType::Operation(operation);
+                Ok(CircuitInstruction {
+                    operation,
+                    qubits: as_tuple(py, qubits)?,
+                    clbits: as_tuple(py, clbits)?,
+                    params,
+                    label,
+                    duration,
+                    unit,
+                    condition,
+                })
+            }
+            OperationInput::Object(op) => {
+                let op = convert_py_to_operation_type(py, op)?;
+                match op.operation {
+                    OperationType::Standard(operation) => {
+                        STANDARD_GATE_MAP
+                            .lock()
+                            .unwrap()
+                            .entry(operation)
+                            .or_insert(op.base_class.unwrap());
+                        let operation = OperationType::Standard(operation);
+                        Ok(CircuitInstruction {
+                            operation,
+                            qubits: as_tuple(py, qubits)?,
+                            clbits: as_tuple(py, clbits)?,
+                            params: op.params,
+                            label: op.label,
+                            duration: op.duration,
+                            unit: op.unit,
+                            condition: op.condition,
+                        })
+                    }
+                    OperationType::Gate(operation) => {
+                        let operation = OperationType::Gate(operation);
+                        Ok(CircuitInstruction {
+                            operation,
+                            qubits: as_tuple(py, qubits)?,
+                            clbits: as_tuple(py, clbits)?,
+                            params: op.params,
+                            label: op.label,
+                            duration: op.duration,
+                            unit: op.unit,
+                            condition: op.condition,
+                        })
+                    }
+                    OperationType::Instruction(operation) => {
+                        let operation = OperationType::Instruction(operation);
+                        Ok(CircuitInstruction {
+                            operation,
+                            qubits: as_tuple(py, qubits)?,
+                            clbits: as_tuple(py, clbits)?,
+                            params: op.params,
+                            label: op.label,
+                            duration: op.duration,
+                            unit: op.unit,
+                            condition: op.condition,
+                        })
+                    }
+                    OperationType::Operation(operation) => {
+                        let operation = OperationType::Operation(operation);
+                        Ok(CircuitInstruction {
+                            operation,
+                            qubits: as_tuple(py, qubits)?,
+                            clbits: as_tuple(py, clbits)?,
+                            params: op.params,
+                            label: op.label,
+                            duration: op.duration,
+                            unit: op.unit,
+                            condition: op.condition,
+                        })
+                    }
+                }
+            }
+        }
     }
 
     /// Returns a shallow copy.
@@ -110,32 +260,83 @@ impl CircuitInstruction {
         self.clone()
     }
 
+    /// The logical operation that this instruction represents an execution of.
+    #[getter]
+    pub fn operation(&self, py: Python) -> PyResult<PyObject> {
+        operation_type_to_py(py, self)
+    }
+
     /// Creates a shallow copy with the given fields replaced.
     ///
     /// Returns:
     ///     CircuitInstruction: A new instance with the given fields replaced.
+    #[allow(clippy::too_many_arguments)]
     pub fn replace(
         &self,
         py: Python<'_>,
-        operation: Option<PyObject>,
+        operation: Option<OperationInput>,
         qubits: Option<&Bound<PyAny>>,
         clbits: Option<&Bound<PyAny>>,
+        params: Option<SmallVec<[Param; 3]>>,
+        label: Option<String>,
+        duration: Option<PyObject>,
+        unit: Option<String>,
+        condition: Option<PyObject>,
     ) -> PyResult<Self> {
+        let operation = match operation {
+            Some(operation) => operation,
+            None => match &self.operation {
+                OperationType::Standard(op) => OperationInput::Standard(*op),
+                OperationType::Gate(gate) => OperationInput::Gate(gate.clone()),
+                OperationType::Instruction(inst) => OperationInput::Instruction(inst.clone()),
+                OperationType::Operation(op) => OperationInput::Operation(op.clone()),
+            },
+        };
+
+        let params = match params {
+            Some(params) => Some(params),
+            None => self.params.clone(),
+        };
+
+        let label = match label {
+            Some(label) => Some(label),
+            None => self.label.clone(),
+        };
+        let duration = match duration {
+            Some(duration) => Some(duration),
+            None => self.duration.clone(),
+        };
+
+        let unit: Option<String> = match unit {
+            Some(unit) => Some(unit),
+            None => self.unit.clone(),
+        };
+
+        let condition: Option<PyObject> = match condition {
+            Some(condition) => Some(condition),
+            None => self.condition.clone(),
+        };
+
         CircuitInstruction::new(
             py,
-            operation.unwrap_or_else(|| self.operation.clone_ref(py)),
+            operation,
             Some(qubits.unwrap_or_else(|| self.qubits.bind(py))),
             Some(clbits.unwrap_or_else(|| self.clbits.bind(py))),
+            params,
+            label,
+            duration,
+            unit,
+            condition,
         )
     }
 
-    fn __getstate__(&self, py: Python<'_>) -> PyObject {
-        (
-            self.operation.bind(py),
+    fn __getstate__(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok((
+            operation_type_to_py(py, self)?,
             self.qubits.bind(py),
             self.clbits.bind(py),
         )
-            .into_py(py)
+            .into_py(py))
     }
 
     fn __setstate__(&mut self, _py: Python<'_>, state: &Bound<PyTuple>) -> PyResult<()> {
@@ -147,7 +348,7 @@ impl CircuitInstruction {
 
     pub fn __getnewargs__(&self, py: Python<'_>) -> PyResult<PyObject> {
         Ok((
-            self.operation.bind(py),
+            operation_type_to_py(py, self)?,
             self.qubits.bind(py),
             self.clbits.bind(py),
         )
@@ -164,7 +365,7 @@ impl CircuitInstruction {
             , clbits={}\
             )",
             type_name,
-            r.operation.bind(py).repr()?,
+            operation_type_to_py(py, &r)?,
             r.qubits.bind(py).repr()?,
             r.clbits.bind(py).repr()?
         ))
@@ -176,23 +377,20 @@ impl CircuitInstruction {
     // the interface to behave exactly like the old 3-tuple `(inst, qargs, cargs)` if it's treated
     // like that via unpacking or similar.  That means that the `parameters` field is completely
     // absent, and the qubits and clbits must be converted to lists.
-    pub fn _legacy_format<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
-        PyTuple::new_bound(
+    pub fn _legacy_format<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let op = operation_type_to_py(py, self)?;
+        Ok(PyTuple::new_bound(
             py,
-            [
-                self.operation.bind(py),
-                &self.qubits.bind(py).to_list(),
-                &self.clbits.bind(py).to_list(),
-            ],
-        )
+            [op, self.qubits.to_object(py), self.clbits.to_object(py)],
+        ))
     }
 
     pub fn __getitem__(&self, py: Python<'_>, key: &Bound<PyAny>) -> PyResult<PyObject> {
-        Ok(self._legacy_format(py).as_any().get_item(key)?.into_py(py))
+        Ok(self._legacy_format(py)?.as_any().get_item(key)?.into_py(py))
     }
 
     pub fn __iter__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(self._legacy_format(py).as_any().iter()?.into_py(py))
+        Ok(self._legacy_format(py)?.as_any().iter()?.into_py(py))
     }
 
     pub fn __len__(&self) -> usize {
@@ -219,16 +417,48 @@ impl CircuitInstruction {
                 let other: PyResult<Bound<CircuitInstruction>> = other.extract();
                 return other.map_or(Ok(Some(false)), |v| {
                     let v = v.try_borrow()?;
+                    let op_eq = match &self_.operation {
+                        OperationType::Standard(op) => {
+                            if let OperationType::Standard(other) = &v.operation {
+                                op.name() == other.name()
+                            } else {
+                                false
+                            }
+                        }
+                        OperationType::Gate(op) => {
+                            if let OperationType::Gate(other) = &v.operation {
+                                op.gate.bind(py).eq(other.gate.bind(py))?
+                            } else {
+                                false
+                            }
+                        }
+                        OperationType::Instruction(op) => {
+                            if let OperationType::Instruction(other) = &v.operation {
+                                op.instruction.bind(py).eq(other.instruction.bind(py))?
+                            } else {
+                                false
+                            }
+                        }
+                        OperationType::Operation(op) => {
+                            if let OperationType::Operation(other) = &v.operation {
+                                op.operation.bind(py).eq(other.operation.bind(py))?
+                            } else {
+                                false
+                            }
+                        }
+                    };
+
                     Ok(Some(
                         self_.clbits.bind(py).eq(v.clbits.bind(py))?
                             && self_.qubits.bind(py).eq(v.qubits.bind(py))?
-                            && self_.operation.bind(py).eq(v.operation.bind(py))?,
+                            && op_eq,
                     ))
                 });
             }
 
             if other.is_instance_of::<PyTuple>() {
-                return Ok(Some(self_._legacy_format(py).eq(other)?));
+                let legacy_format = self_._legacy_format(py)?;
+                return Ok(Some(legacy_format.eq(other)?));
             }
 
             Ok(None)
@@ -246,4 +476,312 @@ impl CircuitInstruction {
             _ => Ok(py.NotImplemented()),
         }
     }
+}
+
+pub(crate) fn operation_type_to_py(
+    py: Python,
+    circuit_inst: &CircuitInstruction,
+) -> PyResult<PyObject> {
+    operation_type_and_data_to_py(
+        py,
+        &circuit_inst.operation,
+        &circuit_inst.params,
+        &circuit_inst.label,
+        &circuit_inst.duration,
+        &circuit_inst.unit,
+    )
+}
+
+pub(crate) fn operation_type_and_data_to_py(
+    py: Python,
+    operation: &OperationType,
+    params: &Option<SmallVec<[Param; 3]>>,
+    label: &Option<String>,
+    duration: &Option<PyObject>,
+    unit: &Option<String>,
+) -> PyResult<PyObject> {
+    match &operation {
+        OperationType::Standard(op) => {
+            let gate_class: &PyObject = &STANDARD_GATE_MAP.lock().unwrap()[op];
+
+            let args = if let Some(params) = &params {
+                if params.is_empty() {
+                    PyTuple::empty_bound(py)
+                } else {
+                    PyTuple::new_bound(py, params)
+                }
+            } else {
+                PyTuple::new_bound(py, params)
+            };
+            let kwargs = [
+                ("label", label.to_object(py)),
+                ("unit", unit.to_object(py)),
+                ("duration", duration.to_object(py)),
+                //                ("condition", circuit_inst.condition.to_object(py)),
+            ]
+            .into_py_dict_bound(py);
+            gate_class.call_bound(py, args, Some(&kwargs))
+        }
+        OperationType::Gate(gate) => Ok(gate.gate.clone_ref(py)),
+        OperationType::Instruction(inst) => Ok(inst.instruction.clone_ref(py)),
+        OperationType::Operation(op) => Ok(op.operation.clone_ref(py)),
+    }
+}
+
+/// A container struct that contains the output from the Python object to
+/// conversion to construct a CircuitInstruction object
+#[derive(Debug)]
+pub(crate) struct OperationTypeConstruct {
+    pub operation: OperationType,
+    pub base_class: Option<PyObject>,
+    pub params: Option<SmallVec<[Param; 3]>>,
+    pub label: Option<String>,
+    pub duration: Option<PyObject>,
+    pub unit: Option<String>,
+    pub condition: Option<PyObject>,
+}
+
+pub(crate) fn convert_py_to_operation_type(
+    py: Python,
+    py_op: PyObject,
+) -> PyResult<OperationTypeConstruct> {
+    let attr = intern!(py, "_standard_gate");
+    let op_type = py_op.clone_ref(py).into_bound(py).get_type();
+    let standard: Option<StandardGate> = match op_type.getattr(attr).ok() {
+        Some(stdgate) => match stdgate.extract().ok() {
+            Some(gate) => gate,
+            None => None,
+        },
+        None => None,
+    };
+    if let Some(op) = standard {
+        return Ok(OperationTypeConstruct {
+            operation: OperationType::Standard(op),
+            base_class: Some(op_type.to_object(py)),
+            params: py_op
+                .getattr(py, intern!(py, "params"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            label: py_op
+                .getattr(py, intern!(py, "label"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            duration: py_op
+                .getattr(py, intern!(py, "duration"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            unit: py_op
+                .getattr(py, intern!(py, "unit"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            condition: py_op
+                .getattr(py, intern!(py, "condition"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+        });
+    }
+    let gate_class = py
+        .import_bound("qiskit.circuit.gate")?
+        .getattr(intern!(py, "Gate"))
+        .ok()
+        .unwrap();
+    if op_type.is_subclass(&gate_class)? {
+        let params = py_op
+            .getattr(py, intern!(py, "params"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let label = py_op
+            .getattr(py, intern!(py, "label"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let duration = py_op
+            .getattr(py, intern!(py, "duration"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let unit = py_op
+            .getattr(py, intern!(py, "unit"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let condition = py_op
+            .getattr(py, intern!(py, "condition"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+
+        let out_op = PyGate {
+            qubits: py_op
+                .getattr(py, intern!(py, "num_qubits"))
+                .ok()
+                .map(|x| x.extract(py).unwrap())
+                .unwrap_or(0),
+            clbits: py_op
+                .getattr(py, intern!(py, "num_clbits"))
+                .ok()
+                .map(|x| x.extract(py).unwrap())
+                .unwrap_or(0),
+            params: py_op
+                .getattr(py, intern!(py, "params"))
+                .ok()
+                .unwrap()
+                .downcast_bound::<PyList>(py)?
+                .len() as u32,
+            op_name: py_op
+                .getattr(py, intern!(py, "name"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            gate: py_op,
+        };
+        return Ok(OperationTypeConstruct {
+            operation: OperationType::Gate(out_op),
+            base_class: None,
+            params,
+            label,
+            duration,
+            unit,
+            condition,
+        });
+    }
+    let instruction_class = py
+        .import_bound("qiskit.circuit.instruction")?
+        .getattr(intern!(py, "Instruction"))
+        .ok()
+        .unwrap();
+    if op_type.is_subclass(&instruction_class)? {
+        let params = py_op
+            .getattr(py, intern!(py, "params"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let label = py_op
+            .getattr(py, intern!(py, "label"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let duration = py_op
+            .getattr(py, intern!(py, "duration"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let unit = py_op
+            .getattr(py, intern!(py, "unit"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let condition = py_op
+            .getattr(py, intern!(py, "condition"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+
+        let out_op = PyInstruction {
+            qubits: py_op
+                .getattr(py, intern!(py, "num_qubits"))
+                .ok()
+                .map(|x| x.extract(py).unwrap())
+                .unwrap_or(0),
+            clbits: py_op
+                .getattr(py, intern!(py, "num_clbits"))
+                .ok()
+                .map(|x| x.extract(py).unwrap())
+                .unwrap_or(0),
+            params: py_op
+                .getattr(py, intern!(py, "params"))
+                .ok()
+                .unwrap()
+                .downcast_bound::<PyList>(py)?
+                .len() as u32,
+            op_name: py_op
+                .getattr(py, intern!(py, "name"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            instruction: py_op,
+        };
+        return Ok(OperationTypeConstruct {
+            operation: OperationType::Instruction(out_op),
+            base_class: None,
+            params,
+            label,
+            duration,
+            unit,
+            condition,
+        });
+    }
+
+    let operation_class = py
+        .import_bound("qiskit.circuit.operation")?
+        .getattr(intern!(py, "Operation"))
+        .ok()
+        .unwrap();
+    if op_type.is_subclass(&operation_class)? {
+        let params = py_op
+            .getattr(py, intern!(py, "params"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let label = py_op
+            .getattr(py, intern!(py, "label"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let duration = py_op
+            .getattr(py, intern!(py, "duration"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let unit = py_op
+            .getattr(py, intern!(py, "unit"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let condition = py_op
+            .getattr(py, intern!(py, "condition"))
+            .ok()
+            .unwrap()
+            .extract(py)?;
+        let out_op = PyOperation {
+            qubits: py_op
+                .getattr(py, intern!(py, "num_qubits"))
+                .ok()
+                .map(|x| x.extract(py).unwrap())
+                .unwrap_or(0),
+            clbits: py_op
+                .getattr(py, intern!(py, "num_clbits"))
+                .ok()
+                .map(|x| x.extract(py).unwrap())
+                .unwrap_or(0),
+            params: py_op
+                .getattr(py, intern!(py, "params"))
+                .ok()
+                .unwrap()
+                .downcast_bound::<PyList>(py)?
+                .len() as u32,
+            op_name: py_op
+                .getattr(py, intern!(py, "name"))
+                .ok()
+                .unwrap()
+                .extract(py)?,
+            operation: py_op,
+        };
+        return Ok(OperationTypeConstruct {
+            operation: OperationType::Operation(out_op),
+            base_class: None,
+            params,
+            label,
+            duration,
+            unit,
+            condition,
+        });
+    }
+    Err(PyValueError::new_err(format!("Invalid input: {}", py_op)))
 }

--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -18,10 +18,27 @@
 // of real components and one of imaginary components.
 // In order to avoid copying we want to use `MatRef<c64>` or `MatMut<c64>`.
 
-use num_complex::Complex64;
+use num_complex::{Complex64, Complex};
 use std::f64::consts::FRAC_1_SQRT_2;
 
+// This is almost the same as the function that became available in
+// num-complex 0.4.6. The difference is that two generic parameters are
+// used here rather than one. This allows call like `c64(half_theta.cos(), 0);`
+// that mix f64 and integer arguments.
+/// Create a new [`Complex<f64>`] with arguments that can convert [`Into<f64>`].
+///
+/// ```
+/// use num_complex::{c64, Complex64};
+/// assert_eq!(c64(1, 2), Complex64::new(1.0, 2.0));
+/// ```
+#[inline]
+fn c64<T: Into<f64>, V: Into<f64>>(re: T, im: V) -> Complex64 {
+    Complex::new(re.into(), im.into())
+}
+
 // Many computations are not avaialable when these `const`s are compiled.
+
+// ZERO and ONE are defined in num_complex 0.4.6
 const ZERO: Complex64 = Complex64::new(0., 0.);
 const ONE: Complex64 = Complex64::new(1., 0.);
 const M_ONE: Complex64 = Complex64::new(-1., 0.);
@@ -32,20 +49,20 @@ pub static ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [[ONE, ZERO], [ZERO, ONE]];
 
 pub fn rx_gate(theta: f64) -> [[Complex64; 2]; 2] {
     let half_theta = theta / 2.;
-    let cos = Complex64::new(half_theta.cos(), 0.);
-    let isin = Complex64::new(0., -half_theta.sin());
+    let cos = c64(half_theta.cos(), 0);
+    let isin = c64(0., -half_theta.sin());
     [[cos, isin], [isin, cos]]
 }
 
 pub fn ry_gate(theta: f64) -> [[Complex64; 2]; 2] {
     let half_theta = theta / 2.;
-    let cos = Complex64::new(half_theta.cos(), 0.);
-    let sin = Complex64::new(half_theta.sin(), 0.);
+    let cos = c64(half_theta.cos(), 0);
+    let sin = c64(half_theta.sin(), 0);
     [[cos, -sin], [sin, cos]]
 }
 
 pub fn rz_gate(theta: f64) -> [[Complex64; 2]; 2] {
-    let ilam2 = Complex64::new(0., 0.5 * theta);
+    let ilam2 = c64(0, 0.5 * theta);
     [[(-ilam2).exp(), ZERO], [ZERO, ilam2.exp()]]
 }
 
@@ -138,9 +155,9 @@ pub static SWAPGATE: [[Complex64; 4]; 4] = [
 ];
 
 pub fn global_phase_gate(theta: f64) -> [[Complex64; 1]; 1] {
-    [[Complex64::new(0., theta).exp()]]
+    [[c64(0., theta).exp()]]
 }
 
 pub fn phase_gate(lam: f64) -> [[Complex64; 2]; 2] {
-    [[ONE, ZERO], [ZERO, Complex64::new(0., lam).exp()]]
+    [[ONE, ZERO], [ZERO, c64(0., lam).exp()]]
 }

--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -1,0 +1,309 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2023
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+// In numpy matrices real and imaginary components are adjacent:
+//   np.array([1,2,3], dtype='complex').view('float64')
+//   array([1., 0., 2., 0., 3., 0.])
+// The matrix faer::Mat<c64> has this layout.
+// faer::Mat<num_complex::Complex<f64>> instead stores a matrix
+// of real components and one of imaginary components.
+// In order to avoid copying we want to use `MatRef<c64>` or `MatMut<c64>`.
+
+use num_complex::Complex64;
+use std::f64::consts::FRAC_1_SQRT_2;
+
+pub static ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [
+    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
+];
+
+pub fn rx_gate(theta: f64) -> [[Complex64; 2]; 2] {
+    let half_theta = theta / 2.;
+    let cos = Complex64::new(half_theta.cos(), 0.);
+    let isin = Complex64::new(0., -half_theta.sin());
+    [[cos, isin], [isin, cos]]
+}
+
+pub fn ry_gate(theta: f64) -> [[Complex64; 2]; 2] {
+    let half_theta = theta / 2.;
+    let cos = Complex64::new(half_theta.cos(), 0.);
+    let sin = Complex64::new(half_theta.sin(), 0.);
+    [[cos, -sin], [sin, cos]]
+}
+
+pub fn rz_gate(theta: f64) -> [[Complex64; 2]; 2] {
+    let ilam2 = Complex64::new(0., 0.5 * theta);
+    [
+        [(-ilam2).exp(), Complex64::new(0., 0.)],
+        [Complex64::new(0., 0.), ilam2.exp()],
+    ]
+}
+
+pub static HGATE: [[Complex64; 2]; 2] = [
+    [
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+    ],
+    [
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+        Complex64::new(-FRAC_1_SQRT_2, 0.),
+    ],
+];
+
+pub static CXGATE: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+];
+
+pub static SXGATE: [[Complex64; 2]; 2] = [
+    [Complex64::new(0.5, 0.5), Complex64::new(0.5, -0.5)],
+    [Complex64::new(0.5, -0.5), Complex64::new(0.5, 0.5)],
+];
+
+pub static XGATE: [[Complex64; 2]; 2] = [
+    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
+    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+];
+
+pub static ZGATE: [[Complex64; 2]; 2] = [
+    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+    [Complex64::new(0., 0.), Complex64::new(-1., 0.)],
+];
+
+pub static YGATE: [[Complex64; 2]; 2] = [
+    [Complex64::new(0., -1.), Complex64::new(0., 0.)],
+    [Complex64::new(0., 1.), Complex64::new(0., 0.)],
+];
+
+pub static CZGATE: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(-1., 0.),
+    ],
+];
+
+pub static CYGATE: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., -1.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 1.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+];
+
+pub static CCXGATE: [[Complex64; 8]; 8] = [
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+];
+
+pub static ECRGATE: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., FRAC_1_SQRT_2),
+    ],
+    [
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., -FRAC_1_SQRT_2),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., FRAC_1_SQRT_2),
+        Complex64::new(0., 0.),
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+    ],
+    [
+        Complex64::new(0., -FRAC_1_SQRT_2),
+        Complex64::new(0., 0.),
+        Complex64::new(FRAC_1_SQRT_2, 0.),
+        Complex64::new(0., 0.),
+    ],
+];
+
+pub static SWAPGATE: [[Complex64; 4]; 4] = [
+    [
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+    ],
+    [
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(0., 0.),
+        Complex64::new(1., 0.),
+    ],
+];
+
+pub fn global_phase_gate(theta: f64) -> [[Complex64; 1]; 1] {
+    [[Complex64::new(0., theta).exp()]]
+}
+
+pub fn phase_gate(lam: f64) -> [[Complex64; 2]; 2] {
+    [
+        [Complex64::new(1., 0.), Complex64::new(0., 0.)],
+        [Complex64::new(0., 0.), Complex64::new(0., lam).exp()],
+    ]
+}

--- a/crates/circuit/src/gate_matrix.rs
+++ b/crates/circuit/src/gate_matrix.rs
@@ -21,10 +21,14 @@
 use num_complex::Complex64;
 use std::f64::consts::FRAC_1_SQRT_2;
 
-pub static ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [
-    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
-];
+// Many computations are not avaialable when these `const`s are compiled.
+const ZERO: Complex64 = Complex64::new(0., 0.);
+const ONE: Complex64 = Complex64::new(1., 0.);
+const M_ONE: Complex64 = Complex64::new(-1., 0.);
+const IM: Complex64 = Complex64::new(0., 1.);
+const M_IM: Complex64 = Complex64::new(0., -1.);
+
+pub static ONE_QUBIT_IDENTITY: [[Complex64; 2]; 2] = [[ONE, ZERO], [ZERO, ONE]];
 
 pub fn rx_gate(theta: f64) -> [[Complex64; 2]; 2] {
     let half_theta = theta / 2.;
@@ -42,10 +46,7 @@ pub fn ry_gate(theta: f64) -> [[Complex64; 2]; 2] {
 
 pub fn rz_gate(theta: f64) -> [[Complex64; 2]; 2] {
     let ilam2 = Complex64::new(0., 0.5 * theta);
-    [
-        [(-ilam2).exp(), Complex64::new(0., 0.)],
-        [Complex64::new(0., 0.), ilam2.exp()],
-    ]
+    [[(-ilam2).exp(), ZERO], [ZERO, ilam2.exp()]]
 }
 
 pub static HGATE: [[Complex64; 2]; 2] = [
@@ -60,30 +61,10 @@ pub static HGATE: [[Complex64; 2]; 2] = [
 ];
 
 pub static CXGATE: [[Complex64; 4]; 4] = [
-    [
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
+    [ONE, ZERO, ZERO, ZERO],
+    [ZERO, ZERO, ZERO, ONE],
+    [ZERO, ZERO, ONE, ZERO],
+    [ZERO, ONE, ZERO, ZERO],
 ];
 
 pub static SXGATE: [[Complex64; 2]; 2] = [
@@ -91,210 +72,69 @@ pub static SXGATE: [[Complex64; 2]; 2] = [
     [Complex64::new(0.5, -0.5), Complex64::new(0.5, 0.5)],
 ];
 
-pub static XGATE: [[Complex64; 2]; 2] = [
-    [Complex64::new(0., 0.), Complex64::new(1., 0.)],
-    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-];
+pub static XGATE: [[Complex64; 2]; 2] = [[ZERO, ONE], [ONE, ZERO]];
 
-pub static ZGATE: [[Complex64; 2]; 2] = [
-    [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-    [Complex64::new(0., 0.), Complex64::new(-1., 0.)],
-];
+pub static ZGATE: [[Complex64; 2]; 2] = [[ONE, ZERO], [ZERO, M_ONE]];
 
-pub static YGATE: [[Complex64; 2]; 2] = [
-    [Complex64::new(0., -1.), Complex64::new(0., 0.)],
-    [Complex64::new(0., 1.), Complex64::new(0., 0.)],
-];
+pub static YGATE: [[Complex64; 2]; 2] = [[M_IM, ZERO], [IM, ZERO]];
 
 pub static CZGATE: [[Complex64; 4]; 4] = [
-    [
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(-1., 0.),
-    ],
+    [ONE, ZERO, ZERO, ZERO],
+    [ZERO, ONE, ZERO, ZERO],
+    [ZERO, ZERO, ONE, ZERO],
+    [ZERO, ZERO, ZERO, M_ONE],
 ];
 
 pub static CYGATE: [[Complex64; 4]; 4] = [
-    [
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., -1.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 1.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
+    [ONE, ZERO, ZERO, ZERO],
+    [ZERO, ZERO, ZERO, M_IM],
+    [ZERO, ZERO, ONE, ZERO],
+    [ZERO, IM, ZERO, ZERO],
 ];
 
 pub static CCXGATE: [[Complex64; 8]; 8] = [
-    [
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
+    [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
+    [ZERO, ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
+    [ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO, ZERO],
+    [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE],
+    [ZERO, ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO],
+    [ZERO, ZERO, ZERO, ZERO, ZERO, ONE, ZERO, ZERO],
+    [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE, ZERO],
+    [ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO],
 ];
 
 pub static ECRGATE: [[Complex64; 4]; 4] = [
     [
-        Complex64::new(0., 0.),
+        ZERO,
         Complex64::new(FRAC_1_SQRT_2, 0.),
-        Complex64::new(0., 0.),
+        ZERO,
         Complex64::new(0., FRAC_1_SQRT_2),
     ],
     [
         Complex64::new(FRAC_1_SQRT_2, 0.),
-        Complex64::new(0., 0.),
+        ZERO,
         Complex64::new(0., -FRAC_1_SQRT_2),
-        Complex64::new(0., 0.),
+        ZERO,
     ],
     [
-        Complex64::new(0., 0.),
+        ZERO,
         Complex64::new(0., FRAC_1_SQRT_2),
-        Complex64::new(0., 0.),
+        ZERO,
         Complex64::new(FRAC_1_SQRT_2, 0.),
     ],
     [
         Complex64::new(0., -FRAC_1_SQRT_2),
-        Complex64::new(0., 0.),
+        ZERO,
         Complex64::new(FRAC_1_SQRT_2, 0.),
-        Complex64::new(0., 0.),
+        ZERO,
     ],
 ];
 
 pub static SWAPGATE: [[Complex64; 4]; 4] = [
-    [
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-    ],
-    [
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(0., 0.),
-        Complex64::new(1., 0.),
-    ],
+    [ONE, ZERO, ZERO, ZERO],
+    [ZERO, ZERO, ONE, ZERO],
+    [ZERO, ONE, ZERO, ZERO],
+    [ZERO, ZERO, ZERO, ONE],
 ];
 
 pub fn global_phase_gate(theta: f64) -> [[Complex64; 1]; 1] {
@@ -302,8 +142,5 @@ pub fn global_phase_gate(theta: f64) -> [[Complex64; 1]; 1] {
 }
 
 pub fn phase_gate(lam: f64) -> [[Complex64; 2]; 2] {
-    [
-        [Complex64::new(1., 0.), Complex64::new(0., 0.)],
-        [Complex64::new(0., 0.), Complex64::new(0., lam).exp()],
-    ]
+    [[ONE, ZERO], [ZERO, Complex64::new(0., lam).exp()]]
 }

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -12,7 +12,9 @@
 
 pub mod circuit_data;
 pub mod circuit_instruction;
+pub mod gate_matrix;
 pub mod intern_context;
+pub mod operations;
 
 use pyo3::prelude::*;
 use pyo3::types::PySlice;
@@ -31,5 +33,9 @@ pub enum SliceOrInt<'a> {
 pub fn circuit(m: Bound<PyModule>) -> PyResult<()> {
     m.add_class::<circuit_data::CircuitData>()?;
     m.add_class::<circuit_instruction::CircuitInstruction>()?;
+    m.add_class::<operations::StandardGate>()?;
+    m.add_class::<operations::PyInstruction>()?;
+    m.add_class::<operations::PyGate>()?;
+    m.add_class::<operations::PyOperation>()?;
     Ok(())
 }

--- a/crates/circuit/src/operations.rs
+++ b/crates/circuit/src/operations.rs
@@ -1,0 +1,485 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2024
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use crate::circuit_data::CircuitData;
+use crate::gate_matrix;
+use ndarray::{aview2, Array2};
+use num_complex::Complex64;
+use numpy::PyReadonlyArray2;
+use pyo3::prelude::*;
+use pyo3::{intern, IntoPy, Python};
+use smallvec::SmallVec;
+
+/// Valid types for OperationType
+#[derive(FromPyObject, Clone, Debug)]
+pub enum OperationType {
+    Standard(StandardGate),
+    Instruction(PyInstruction),
+    Gate(PyGate),
+    Operation(PyOperation),
+}
+
+impl Operation for OperationType {
+    fn name(&self) -> &str {
+        match self {
+            Self::Standard(op) => op.name(),
+            Self::Gate(op) => op.name(),
+            Self::Instruction(op) => op.name(),
+            Self::Operation(op) => op.name(),
+        }
+    }
+
+    fn num_qubits(&self) -> u32 {
+        match self {
+            Self::Standard(op) => op.num_qubits(),
+            Self::Gate(op) => op.num_qubits(),
+            Self::Instruction(op) => op.num_qubits(),
+            Self::Operation(op) => op.num_qubits(),
+        }
+    }
+    fn num_clbits(&self) -> u32 {
+        match self {
+            Self::Standard(op) => op.num_clbits(),
+            Self::Gate(op) => op.num_clbits(),
+            Self::Instruction(op) => op.num_clbits(),
+            Self::Operation(op) => op.num_clbits(),
+        }
+    }
+
+    fn num_params(&self) -> u32 {
+        match self {
+            Self::Standard(op) => op.num_params(),
+            Self::Gate(op) => op.num_params(),
+            Self::Instruction(op) => op.num_params(),
+            Self::Operation(op) => op.num_params(),
+        }
+    }
+    fn matrix(&self, params: Option<SmallVec<[Param; 3]>>) -> Option<Array2<Complex64>> {
+        match self {
+            Self::Standard(op) => op.matrix(params),
+            Self::Gate(op) => op.matrix(params),
+            Self::Instruction(op) => op.matrix(params),
+            Self::Operation(op) => op.matrix(params),
+        }
+    }
+
+    fn control_flow(&self) -> bool {
+        match self {
+            Self::Standard(op) => op.control_flow(),
+            Self::Gate(op) => op.control_flow(),
+            Self::Instruction(op) => op.control_flow(),
+            Self::Operation(op) => op.control_flow(),
+        }
+    }
+
+    fn definition(&self, params: Option<SmallVec<[Param; 3]>>) -> Option<CircuitData> {
+        match self {
+            Self::Standard(op) => op.definition(params),
+            Self::Gate(op) => op.definition(params),
+            Self::Instruction(op) => op.definition(params),
+            Self::Operation(op) => op.definition(params),
+        }
+    }
+}
+
+/// Trait for generic circuit operations these define the common attributes
+/// needed for something to be addable to the circuit struct
+pub trait Operation {
+    fn name(&self) -> &str;
+    fn num_qubits(&self) -> u32;
+    fn num_clbits(&self) -> u32;
+    fn num_params(&self) -> u32;
+    fn control_flow(&self) -> bool;
+    fn matrix(&self, params: Option<SmallVec<[Param; 3]>>) -> Option<Array2<Complex64>>;
+    fn definition(&self, params: Option<SmallVec<[Param; 3]>>) -> Option<CircuitData>;
+    // fn control_flow_body(&self) -> Option<CircuitData>;
+}
+
+#[derive(FromPyObject, Clone, Debug)]
+pub enum Param {
+    Float(f64),
+    ParameterExpression(PyObject),
+}
+
+impl IntoPy<PyObject> for Param {
+    fn into_py(self, py: Python) -> PyObject {
+        match &self {
+            Self::Float(val) => val.to_object(py),
+            Self::ParameterExpression(val) => val.clone_ref(py),
+        }
+    }
+}
+
+impl ToPyObject for Param {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            Self::Float(val) => val.to_object(py),
+            Self::ParameterExpression(val) => val.clone_ref(py),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Copy, Eq, PartialEq, Hash)]
+#[pyclass]
+pub enum StandardGate {
+    // Pauli Gates
+    ZGate,
+    YGate,
+    XGate,
+    // Controlled Pauli Gates
+    CZGate,
+    CYGate,
+    CXGate,
+    CCXGate,
+    RXGate,
+    RYGate,
+    RZGate,
+    ECRGate,
+    SwapGate,
+    SXGate,
+    GlobalPhaseGate,
+    IGate,
+    HGate,
+    PhaseGate,
+}
+
+#[pymethods]
+impl StandardGate {
+    pub fn copy(&self) -> Self {
+        *self
+    }
+}
+
+// This must be kept up-to-date with `StandardGate` when adding or removing
+// gates from the enum
+//
+// Remove this when std::mem::variant_count() is stabilized (see
+// https://github.com/rust-lang/rust/issues/73662 )
+pub const STANDARD_GATE_SIZE: usize = 17;
+
+impl Operation for StandardGate {
+    fn name(&self) -> &str {
+        match self {
+            Self::ZGate => "z",
+            Self::YGate => "y",
+            Self::XGate => "x",
+            Self::CZGate => "cz",
+            Self::CYGate => "cy",
+            Self::CXGate => "cx",
+            Self::CCXGate => "ccx",
+            Self::RXGate => "rx",
+            Self::RYGate => "ry",
+            Self::RZGate => "rz",
+            Self::ECRGate => "ecr",
+            Self::SwapGate => "swap",
+            Self::SXGate => "sx",
+            Self::GlobalPhaseGate => "global_phase",
+            Self::IGate => "i",
+            Self::HGate => "h",
+            Self::PhaseGate => "p",
+        }
+    }
+
+    fn num_qubits(&self) -> u32 {
+        match self {
+            Self::ZGate => 1,
+            Self::YGate => 1,
+            Self::XGate => 1,
+            Self::CZGate => 2,
+            Self::CYGate => 2,
+            Self::CXGate => 2,
+            Self::CCXGate => 3,
+            Self::RXGate => 1,
+            Self::RYGate => 1,
+            Self::RZGate => 1,
+            Self::ECRGate => 2,
+            Self::SwapGate => 2,
+            Self::SXGate => 1,
+            Self::GlobalPhaseGate => 0,
+            Self::IGate => 1,
+            Self::HGate => 1,
+            Self::PhaseGate => 1,
+        }
+    }
+
+    fn num_params(&self) -> u32 {
+        match self {
+            Self::ZGate => 0,
+            Self::YGate => 0,
+            Self::XGate => 0,
+            Self::CZGate => 0,
+            Self::CYGate => 0,
+            Self::CXGate => 0,
+            Self::CCXGate => 0,
+            Self::RXGate => 1,
+            Self::RYGate => 1,
+            Self::RZGate => 1,
+            Self::ECRGate => 0,
+            Self::SwapGate => 0,
+            Self::SXGate => 0,
+            Self::GlobalPhaseGate => 1,
+            Self::IGate => 0,
+            Self::HGate => 0,
+            Self::PhaseGate => 1,
+        }
+    }
+
+    fn num_clbits(&self) -> u32 {
+        0
+    }
+
+    fn control_flow(&self) -> bool {
+        false
+    }
+
+    fn matrix(&self, params: Option<SmallVec<[Param; 3]>>) -> Option<Array2<Complex64>> {
+        match self {
+            Self::ZGate => Some(aview2(&gate_matrix::ZGATE).to_owned()),
+            Self::YGate => Some(aview2(&gate_matrix::YGATE).to_owned()),
+            Self::XGate => Some(aview2(&gate_matrix::XGATE).to_owned()),
+            Self::CZGate => Some(aview2(&gate_matrix::CZGATE).to_owned()),
+            Self::CYGate => Some(aview2(&gate_matrix::CYGATE).to_owned()),
+            Self::CXGate => Some(aview2(&gate_matrix::CXGATE).to_owned()),
+            Self::CCXGate => Some(aview2(&gate_matrix::CCXGATE).to_owned()),
+            Self::RXGate => {
+                let theta = &params.unwrap()[0];
+                match theta {
+                    Param::Float(theta) => Some(aview2(&gate_matrix::rx_gate(*theta)).to_owned()),
+                    _ => None,
+                }
+            }
+            Self::RYGate => {
+                let theta = &params.unwrap()[0];
+                match theta {
+                    Param::Float(theta) => Some(aview2(&gate_matrix::ry_gate(*theta)).to_owned()),
+                    _ => None,
+                }
+            }
+            Self::RZGate => {
+                let theta = &params.unwrap()[0];
+                match theta {
+                    Param::Float(theta) => Some(aview2(&gate_matrix::rz_gate(*theta)).to_owned()),
+                    _ => None,
+                }
+            }
+            Self::ECRGate => Some(aview2(&gate_matrix::ECRGATE).to_owned()),
+            Self::SwapGate => Some(aview2(&gate_matrix::SWAPGATE).to_owned()),
+            Self::SXGate => Some(aview2(&gate_matrix::SXGATE).to_owned()),
+            Self::GlobalPhaseGate => {
+                let theta = &params.unwrap()[0];
+                match theta {
+                    Param::Float(theta) => {
+                        Some(aview2(&gate_matrix::global_phase_gate(*theta)).to_owned())
+                    }
+                    _ => None,
+                }
+            }
+            Self::IGate => Some(aview2(&gate_matrix::ONE_QUBIT_IDENTITY).to_owned()),
+            Self::HGate => Some(aview2(&gate_matrix::HGATE).to_owned()),
+            Self::PhaseGate => {
+                let theta = &params.unwrap()[0];
+                match theta {
+                    Param::Float(theta) => {
+                        Some(aview2(&gate_matrix::phase_gate(*theta)).to_owned())
+                    }
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    fn definition(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<CircuitData> {
+        // TODO: Add definition for completeness. This shouldn't be necessary in practice
+        // though because nothing will rely on this in practice.
+        match self {
+            Self::ZGate => Python::with_gil(|py| -> Option<CircuitData> {
+                Some(
+                    CircuitData::build_new_from(
+                        py,
+                        1,
+                        0,
+                        &[(
+                            OperationType::Standard(Self::PhaseGate),
+                            &[Param::Float(std::f64::consts::PI)],
+                            &[0],
+                        )],
+                    )
+                    .expect("TIS_VALID"),
+                )
+            }),
+            _ => None,
+        }
+    }
+}
+
+/// This class is used to wrap a Python side Instruction that is not in the standard library
+#[derive(Clone, Debug)]
+#[pyclass]
+pub struct PyInstruction {
+    pub qubits: u32,
+    pub clbits: u32,
+    pub params: u32,
+    pub op_name: String,
+    pub instruction: PyObject,
+}
+
+impl Operation for PyInstruction {
+    fn name(&self) -> &str {
+        self.op_name.as_str()
+    }
+    fn num_qubits(&self) -> u32 {
+        self.qubits
+    }
+    fn num_clbits(&self) -> u32 {
+        self.clbits
+    }
+    fn num_params(&self) -> u32 {
+        self.params
+    }
+    fn control_flow(&self) -> bool {
+        false
+    }
+    fn matrix(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<Array2<Complex64>> {
+        None
+    }
+    fn definition(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<CircuitData> {
+        Python::with_gil(|py| -> Option<CircuitData> {
+            match self.instruction.getattr(py, intern!(py, "definition")) {
+                Ok(definition) => {
+                    let res: Option<PyObject> = definition.call0(py).ok()?.extract(py).ok();
+                    match res {
+                        Some(x) => {
+                            let out: CircuitData =
+                                x.getattr(py, intern!(py, "data")).ok()?.extract(py).ok()?;
+                            Some(out)
+                        }
+                        None => None,
+                    }
+                }
+                Err(_) => None,
+            }
+        })
+    }
+}
+
+/// This class is used to wrap a Python side Gate that is not in the standard library
+#[derive(Clone, Debug)]
+#[pyclass]
+pub struct PyGate {
+    pub qubits: u32,
+    pub clbits: u32,
+    pub params: u32,
+    pub op_name: String,
+    pub gate: PyObject,
+}
+
+#[pymethods]
+impl PyGate {
+    #[new]
+    fn new(op_name: String, qubits: u32, clbits: u32, params: u32, gate: PyObject) -> Self {
+        PyGate {
+            qubits,
+            clbits,
+            params,
+            op_name,
+            gate,
+        }
+    }
+}
+
+impl Operation for PyGate {
+    fn name(&self) -> &str {
+        self.op_name.as_str()
+    }
+    fn num_qubits(&self) -> u32 {
+        self.qubits
+    }
+    fn num_clbits(&self) -> u32 {
+        self.clbits
+    }
+    fn num_params(&self) -> u32 {
+        self.params
+    }
+    fn control_flow(&self) -> bool {
+        false
+    }
+    fn matrix(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<Array2<Complex64>> {
+        Python::with_gil(|py| -> Option<Array2<Complex64>> {
+            match self.gate.getattr(py, intern!(py, "to_matrix")) {
+                Ok(to_matrix) => {
+                    let res: Option<PyObject> = to_matrix.call0(py).ok()?.extract(py).ok();
+                    match res {
+                        Some(x) => {
+                            let array: PyReadonlyArray2<Complex64> = x.extract(py).ok()?;
+                            Some(array.as_array().to_owned())
+                        }
+                        None => None,
+                    }
+                }
+                Err(_) => None,
+            }
+        })
+    }
+    fn definition(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<CircuitData> {
+        Python::with_gil(|py| -> Option<CircuitData> {
+            match self.gate.getattr(py, intern!(py, "definition")) {
+                Ok(definition) => {
+                    let res: Option<PyObject> = definition.call0(py).ok()?.extract(py).ok();
+                    match res {
+                        Some(x) => {
+                            let out: CircuitData =
+                                x.getattr(py, intern!(py, "data")).ok()?.extract(py).ok()?;
+                            Some(out)
+                        }
+                        None => None,
+                    }
+                }
+                Err(_) => None,
+            }
+        })
+    }
+}
+
+/// This class is used to wrap a Python side Operation that is not in the standard library
+#[derive(Clone, Debug)]
+#[pyclass]
+pub struct PyOperation {
+    pub qubits: u32,
+    pub clbits: u32,
+    pub params: u32,
+    pub op_name: String,
+    pub operation: PyObject,
+}
+
+impl Operation for PyOperation {
+    fn name(&self) -> &str {
+        self.op_name.as_str()
+    }
+    fn num_qubits(&self) -> u32 {
+        self.qubits
+    }
+    fn num_clbits(&self) -> u32 {
+        self.clbits
+    }
+    fn num_params(&self) -> u32 {
+        self.params
+    }
+    fn control_flow(&self) -> bool {
+        false
+    }
+    fn matrix(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<Array2<Complex64>> {
+        None
+    }
+    fn definition(&self, _params: Option<SmallVec<[Param; 3]>>) -> Option<CircuitData> {
+        None
+    }
+}

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -58,6 +58,7 @@ class Instruction(Operation):
     # Class attribute to treat like barrier for transpiler, unroller, drawer
     # NOTE: Using this attribute may change in the future (See issue # 5811)
     _directive = False
+    _standard_gate = None
 
     def __init__(self, name, num_qubits, num_clbits, params, duration=None, unit="dt", label=None):
         """Create a new instruction.

--- a/qiskit/circuit/library/standard_gates/ecr.py
+++ b/qiskit/circuit/library/standard_gates/ecr.py
@@ -17,6 +17,7 @@ import numpy as np
 from qiskit.circuit._utils import with_gate_array
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
+from qiskit._accelerate.circuit import StandardGate
 from .rzx import RZXGate
 from .x import XGate
 
@@ -83,6 +84,8 @@ class ECRGate(SingletonGate):
                     -i  & 1   &  0  & 0
                 \end{pmatrix}
     """
+
+    _standard_gate = StandardGate.ECRGate
 
     def __init__(self, label=None, *, duration=None, unit="dt"):
         """Create new ECR gate."""

--- a/qiskit/circuit/library/standard_gates/global_phase.py
+++ b/qiskit/circuit/library/standard_gates/global_phase.py
@@ -20,6 +20,7 @@ from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit._accelerate.circuit import StandardGate
 
 
 class GlobalPhaseGate(Gate):
@@ -35,6 +36,8 @@ class GlobalPhaseGate(Gate):
                 e^{i\theta}
             \end{pmatrix}
     """
+
+    _standard_gate = StandardGate.GlobalPhaseGate
 
     def __init__(
         self, phase: ParameterValueType, label: Optional[str] = None, *, duration=None, unit="dt"

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -17,6 +17,7 @@ import numpy
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
+from qiskit._accelerate.circuit import StandardGate
 
 _H_ARRAY = 1 / sqrt(2) * numpy.array([[1, 1], [1, -1]], dtype=numpy.complex128)
 
@@ -50,6 +51,8 @@ class HGate(SingletonGate):
                 1 & -1
             \end{pmatrix}
     """
+
+    _standard_gate = StandardGate.HGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new H gate."""

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -15,6 +15,7 @@
 from typing import Optional
 from qiskit.circuit.singleton import SingletonGate, stdlib_singleton_key
 from qiskit.circuit._utils import with_gate_array
+from qiskit._accelerate.circuit import StandardGate
 
 
 @with_gate_array([[1, 0], [0, 1]])
@@ -44,6 +45,8 @@ class IGate(SingletonGate):
         q_0: ┤ I ├
              └───┘
     """
+
+    _standard_gate = StandardGate.IGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Identity gate."""

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -19,6 +19,7 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit._accelerate.circuit import StandardGate
 
 
 class PhaseGate(Gate):
@@ -74,6 +75,8 @@ class PhaseGate(Gate):
         Reference for virtual Z gate implementation:
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
+
+    _standard_gate = StandardGate.PhaseGate
 
     def __init__(
         self, theta: ParameterValueType, label: str | None = None, *, duration=None, unit="dt"

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -21,6 +21,7 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit._accelerate.circuit import StandardGate
 
 
 class RXGate(Gate):
@@ -49,6 +50,8 @@ class RXGate(Gate):
                 -i\sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
             \end{pmatrix}
     """
+
+    _standard_gate = StandardGate.RXGate
 
     def __init__(
         self, theta: ParameterValueType, label: Optional[str] = None, *, duration=None, unit="dt"

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -20,6 +20,7 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit._accelerate.circuit import StandardGate
 
 
 class RYGate(Gate):
@@ -48,6 +49,8 @@ class RYGate(Gate):
                 \sin\left(\rotationangle\right) & \cos\left(\rotationangle\right)
             \end{pmatrix}
     """
+
+    _standard_gate = StandardGate.RYGate
 
     def __init__(
         self, theta: ParameterValueType, label: Optional[str] = None, *, duration=None, unit="dt"

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -17,6 +17,7 @@ from qiskit.circuit.gate import Gate
 from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
+from qiskit._accelerate.circuit import StandardGate
 
 
 class RZGate(Gate):
@@ -58,6 +59,8 @@ class RZGate(Gate):
         Reference for virtual Z gate implementation:
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
+
+    _standard_gate = StandardGate.RZGate
 
     def __init__(
         self, phi: ParameterValueType, label: Optional[str] = None, *, duration=None, unit="dt"

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -17,6 +17,7 @@ import numpy
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
+from qiskit._accelerate.circuit import StandardGate
 
 
 _SWAP_ARRAY = numpy.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
@@ -57,6 +58,8 @@ class SwapGate(SingletonGate):
 
         |a, b\rangle \rightarrow |b, a\rangle
     """
+
+    _standard_gate = StandardGate.SwapGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new SWAP gate."""

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
+from qiskit._accelerate.circuit import StandardGate
 
 
 _SX_ARRAY = [[0.5 + 0.5j, 0.5 - 0.5j], [0.5 - 0.5j, 0.5 + 0.5j]]
@@ -61,6 +62,8 @@ class SXGate(SingletonGate):
                     = e^{-i \pi/4} \sqrt{X}
 
     """
+
+    _standard_gate = StandardGate.SXGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new SX gate."""

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -19,6 +19,7 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import _ctrl_state_to_int, with_gate_array, with_controlled_gate_array
+from qiskit._accelerate.circuit import StandardGate
 
 _X_ARRAY = [[0, 1], [1, 0]]
 
@@ -69,6 +70,8 @@ class XGate(SingletonGate):
         |0\rangle \rightarrow |1\rangle \\
         |1\rangle \rightarrow |0\rangle
     """
+
+    _standard_gate = StandardGate.XGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new X gate."""
@@ -211,6 +214,8 @@ class CXGate(SingletonControlledGate):
     .. math::
         `|a, b\rangle \rightarrow |a, a \oplus b\rangle`
     """
+
+    _standard_gate = StandardGate.CXGate
 
     def __init__(
         self,
@@ -361,6 +366,8 @@ class CCXGate(SingletonControlledGate):
                 \end{pmatrix}
 
     """
+
+    _standard_gate = StandardGate.CXGate
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -19,6 +19,7 @@ from typing import Optional, Union
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
+from qiskit._accelerate.circuit import StandardGate
 
 _Y_ARRAY = [[0, -1j], [1j, 0]]
 
@@ -69,6 +70,8 @@ class YGate(SingletonGate):
         |0\rangle \rightarrow i|1\rangle \\
         |1\rangle \rightarrow -i|0\rangle
     """
+
+    _standard_gate = StandardGate.YGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Y gate."""
@@ -196,6 +199,8 @@ class CYGate(SingletonControlledGate):
                 \end{pmatrix}
 
     """
+
+    _standard_gate = StandardGate.CYGate
 
     def __init__(
         self,

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -20,6 +20,7 @@ import numpy
 from qiskit.circuit._utils import with_gate_array, with_controlled_gate_array
 from qiskit.circuit.singleton import SingletonGate, SingletonControlledGate, stdlib_singleton_key
 from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit._accelerate.circuit import StandardGate
 
 from .p import PhaseGate
 
@@ -72,6 +73,8 @@ class ZGate(SingletonGate):
         |0\rangle \rightarrow |0\rangle \\
         |1\rangle \rightarrow -|1\rangle
     """
+
+    _standard_gate = StandardGate.ZGate
 
     def __init__(self, label: Optional[str] = None, *, duration=None, unit="dt"):
         """Create new Z gate."""
@@ -180,6 +183,8 @@ class CZGate(SingletonControlledGate):
     In the computational basis, this gate flips the phase of
     the target qubit if the control qubit is in the :math:`|1\rangle` state.
     """
+
+    _standard_gate = StandardGate.CZGate
 
     def __init__(
         self,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2668,15 +2668,15 @@ class QuantumCircuit:
             return copied
 
         cpy._data.map_ops(memo_copy)
-        cpy._parameter_table = ParameterTable(
-            {
-                param: ParameterReferences(
-                    (operation_copies[id(operation)], param_index)
-                    for operation, param_index in self._parameter_table[param]
-                )
-                for param in self._parameter_table
-            }
-        )
+        #        cpy._parameter_table = ParameterTable(
+        #            {
+        #                param: ParameterReferences(
+        #                    (operation_copies[id(operation)], param_index)
+        #                    for operation, param_index in self._parameter_table[param]
+        #                )
+        #                for param in self._parameter_table
+        #            }
+        #        )
         return cpy
 
     def copy_empty_like(

--- a/qiskit/circuit/quantumcircuitdata.py
+++ b/qiskit/circuit/quantumcircuitdata.py
@@ -20,6 +20,8 @@ import qiskit._accelerate.circuit
 from .exceptions import CircuitError
 from .instruction import Instruction
 from .operation import Operation
+from .instruction import Instruction
+from .gate import Gate
 
 
 CircuitInstruction = qiskit._accelerate.circuit.CircuitInstruction


### PR DESCRIPTION
Something like this might be easier to read.

Many computations  are not allowed when defining and using `const`s. So unfortunately, things like `-ONE` are not allowed.

See for example `CCXGATE`

Pretty sure `Complex64` is Copy, otherwise it would not compile.