### PR TITLE
add tests for peephole transpiler pass

### DIFF
--- a/test/python/transpiler/test_peephole_pass.py
+++ b/test/python/transpiler/test_peephole_pass.py
@@ -1,0 +1,154 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2025.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test peephole optimization pass."""
+
+import unittest
+from test import QiskitTestCase
+from ddt import ddt, data
+
+from qiskit import QuantumCircuit
+from qiskit.circuit import Parameter
+from qiskit.circuit.library import (
+    CXGate,
+    CZGate,
+    RXGate,
+    RZGate,
+    SXGate,
+    RZZGate,
+    RXXGate,
+    RYYGate,
+    RZXGate,
+    CPhaseGate,
+    CRZGate,
+    CRXGate,
+    CRYGate,
+    CUGate,
+)
+from qiskit.transpiler import Target, PassManager
+from qiskit.transpiler.passes.optimization.two_qubit_peephole import TwoQubitPeepholeOptimization
+from qiskit.transpiler.passes import Collect2qBlocks, ConsolidateBlocks, UnitarySynthesis
+
+
+@ddt
+class TestUnitarySynthesisBasisGates(QiskitTestCase):
+    """Test UnitarySynthesis pass with basis gates."""
+
+    @data(
+        RXXGate(0.1),
+        RYYGate(0.1),
+        RZZGate(0.1),
+        RZXGate(0.1),
+        CPhaseGate(0.1),
+        CRZGate(0.1),
+        CRXGate(0.1),
+        CRYGate(0.1),
+        CUGate(0.1, 0.2, 0.3, 0.4),
+    )
+    def test_2_qubit_parametrized_gates_cx_target(self, gate):
+        """Test the synthesis of a circuit containing a 2-qubit parametrized gate
+        on a target with a CX gate"""
+        theta = Parameter("θ")
+        target = Target(num_qubits=2)
+        target.add_instruction(CXGate())
+        target.add_instruction(RZGate(theta))
+        target.add_instruction(SXGate())
+
+        qc = QuantumCircuit(2)
+        qc.append(gate, [0, 1])
+
+        peephole = TwoQubitPeepholeOptimization(target)
+        transpiled_circuit = peephole(qc)
+
+        legacy_path = PassManager(
+            [
+                Collect2qBlocks(),
+                ConsolidateBlocks(target=target),
+                UnitarySynthesis(
+                    target=target,
+                ),
+            ]
+        )
+
+        legacy = legacy_path.run(qc)
+        self.assertDictEqual(
+            dict(sorted(transpiled_circuit.count_ops().items())),
+            dict(sorted(legacy.count_ops().items())),
+        )
+
+    @data(
+        RXXGate(0.1),
+        RYYGate(0.1),
+        RZZGate(0.1),
+        RZXGate(0.1),
+        CPhaseGate(0.1),
+        CRZGate(0.1),
+        CRXGate(0.1),
+        CRYGate(0.1),
+        CUGate(0.1, 0.2, 0.3, 0.4),
+    )
+    def test_2_qubit_parametrized_gates_rzz_target(self, gate):
+        """Test the synthesis of a circuit containing a 2-qubit parametrized gate
+        on a target with a RZZ gate"""
+        theta = Parameter("θ")
+        lam = Parameter("λ")
+        phi = Parameter("ϕ")
+        target = Target(num_qubits=2)
+        target.add_instruction(RXGate(lam))
+        target.add_instruction(RZGate(theta))
+        target.add_instruction(RZZGate(phi))
+
+        qc = QuantumCircuit(2)
+        qc.append(gate, [0, 1])
+
+        peephole = TwoQubitPeepholeOptimization(target)
+        transpiled_circuit = peephole(qc)
+
+        legacy_path = PassManager(
+            [
+                Collect2qBlocks(),
+                ConsolidateBlocks(target=target),
+                UnitarySynthesis(
+                    target=target,
+                ),
+            ]
+        )
+
+        legacy = legacy_path.run(qc)
+        self.assertDictEqual(
+            dict(sorted(transpiled_circuit.count_ops().items())),
+            dict(sorted(legacy.count_ops().items())),
+        )
+
+    def test_2_qubit_rzz_cz_gates_rzz_target(self):
+        """Test the synthesis of a circuit containing a RZZ and CZ gates
+        on a target with RZZ and CZ gates"""
+        theta = Parameter("θ")
+        lam = Parameter("λ")
+        phi = Parameter("ϕ")
+        target = Target(num_qubits=2)
+        target.add_instruction(RXGate(lam))
+        target.add_instruction(RZGate(theta))
+        target.add_instruction(RZZGate(phi))
+        target.add_instruction(CZGate())
+
+        qc = QuantumCircuit(2)
+        qc.rzz(0.2, 0, 1)
+        qc.cz(0, 1)
+
+        peephole = TwoQubitPeepholeOptimization(target)
+        transpiled_circuit = peephole(qc)
+        self.assertEqual(transpiled_circuit.count_ops()["rzz"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Add some preliminary tests.
Note that one of them is failing: 
`test_2_qubit_rzz_cz_gates_rzz_target`: 
peephole pass counts: `{'rx': 8, 'rz': 16, 'rzz': 1} `
legacy counts: `{'rzz': 1}`


### Details and comments


