### PR TITLE
Fix tempfile handling in test_phase_and_bitflip_oracles

### DIFF
--- a/test/python/circuit/library/test_phase_and_bitflip_oracles.py
+++ b/test/python/circuit/library/test_phase_and_bitflip_oracles.py
@@ -122,7 +122,8 @@ class TestPhaseOracleAndGate(QiskitTestCase):
         1 -2 -3 0
         -1 2 3 0
         """
-        filename = tempfile.mkstemp(suffix=".dimacs")[1]
+        f,filename = tempfile.mkstemp(suffix=".dimacs")
+        os.close(f)
         self.addCleanup(os.remove, filename)
         with open(filename, "w") as file:
             file.write(input_3sat_instance)


### PR DESCRIPTION
Update tempfile usage to close the file descriptor after creation.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The `tempfile.mkstemp()` opens the file by default 
We need to close it manually

### Details and comments


